### PR TITLE
1987 sufia tech debt

### DIFF
--- a/app/assets/stylesheets/curation_concerns/modules/forms.scss
+++ b/app/assets/stylesheets/curation_concerns/modules/forms.scss
@@ -38,9 +38,9 @@ legend small {
 form label.optional { font-weight: normal; }
 form label.required { font-weight: bold; }
 
-#set-access-controls {
+.set-access-controls {
   label { font-weight: normal; }
-  & > .form-group { padding: 0 1.75em; }
+  & .form-group { padding: 0 1.75em; }
 
   .form-inline {
     .control-label, label {

--- a/app/views/collections/_form_permission.html.erb
+++ b/app/views/collections/_form_permission.html.erb
@@ -1,4 +1,4 @@
-<div id="set-access-controls">
+<div class="set-access-controls">
   <fieldset>
     <legend>
       Visibility

--- a/app/views/curation_concerns/base/_form_permission.html.erb
+++ b/app/views/curation_concerns/base/_form_permission.html.erb
@@ -4,7 +4,7 @@
 <% elsif f.object.lease_expiration_date %>
   <%= render 'form_permission_under_lease', f: f %>
 <% else %>
-  <fieldset id="set-access-controls">
+  <fieldset class="set-access-controls">
     <legend>
       Visibility
       <small>Who should be able to view or download this content?</small>

--- a/app/views/curation_concerns/base/_form_permission_under_embargo.html.erb
+++ b/app/views/curation_concerns/base/_form_permission_under_embargo.html.erb
@@ -1,4 +1,4 @@
-<fieldset id="set-access-controls">
+<fieldset class="set-access-controls">
   <legend>
     Visibility
     <small>Who should be able to view or download this content?</small>

--- a/app/views/curation_concerns/base/_form_permission_under_lease.html.erb
+++ b/app/views/curation_concerns/base/_form_permission_under_lease.html.erb
@@ -1,4 +1,4 @@
-<fieldset id="set-access-controls">
+<fieldset class="set-access-controls">
   <legend>
     Visibility
     <small>Who should be able to view or download this content?</small>

--- a/app/views/embargoes/edit.html.erb
+++ b/app/views/embargoes/edit.html.erb
@@ -4,7 +4,7 @@
 
 <h2>Current Embargo</h2>
 <%= simple_form_for [main_app, curation_concern] do |f| %>
-  <fieldset id="set-access-controls">
+  <fieldset class="set-access-controls">
     <section class="help-block">
       <p>
         <% if curation_concern.embargo_release_date %>

--- a/app/views/leases/edit.html.erb
+++ b/app/views/leases/edit.html.erb
@@ -4,7 +4,7 @@
 
 <h2>Current Lease</h2>
 <%= simple_form_for curation_concern do |f| %>
-  <fieldset id="set-access-controls">
+  <fieldset class="set-access-controls">
     <section class="help-block">
       <p>
         <% if curation_concern.lease_expiration_date %>


### PR DESCRIPTION
Fixes 1987 in Sufia ; refs #issuenumber

This pr helps clean up tech debt in Sufia, where several styles have been created to do what this one does, in addition to actually copying this style to it.

Changes selector for #set-access-controls .form-group styles from id to class and opens up selector on .form-group from first direct child (<) to any child of .set-access-controls with class .form-group.

@projecthydra/sufia-code-reviewers
