### PR TITLE
Don't disable text selection in file manager

### DIFF
--- a/app/assets/javascripts/curation_concerns/file_manager/sorting.es6
+++ b/app/assets/javascripts/curation_concerns/file_manager/sorting.es6
@@ -14,7 +14,6 @@
 
     initialize_sort() {
       this.element.sortable({handle: ".panel-heading"})
-      this.element.disableSelection()
       this.element.on("sortstop", this.stopped_sorting)
       this.element.on("sortstart", this.started_sorting)
     }


### PR DESCRIPTION
Allows you to do things like select all for the text in the label editor.