### PR TITLE
Pass request to presenters

### DIFF
--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -119,7 +119,7 @@ module CurationConcerns::CurationConcernController
     end
 
     def presenter
-      @presenter ||= show_presenter.new(curation_concern_from_search_results, current_ability)
+      @presenter ||= show_presenter.new(curation_concern_from_search_results, current_ability, request)
     end
 
     def _prefixes

--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -136,7 +136,7 @@ module CurationConcerns
           _, document_list = search_results(params)
           curation_concern = document_list.first
           raise CanCan::AccessDenied unless curation_concern
-          show_presenter.new(curation_concern, current_ability)
+          show_presenter.new(curation_concern, current_ability, request)
         end
       end
 

--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -3,13 +3,15 @@ module CurationConcerns
     include ModelProxy
     include PresentsAttributes
     include ActionView::Helpers::NumberHelper
-    attr_accessor :solr_document, :current_ability
+    attr_accessor :solr_document, :current_ability, :request
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
-    def initialize(solr_document, current_ability)
+    # @param [ActionDispatch::Request] request the http request context
+    def initialize(solr_document, current_ability, request = nil)
       @solr_document = solr_document
       @current_ability = current_ability
+      @request = request
     end
 
     # CurationConcern methods

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -2,13 +2,15 @@ module CurationConcerns
   class FileSetPresenter
     include ModelProxy
     include PresentsAttributes
-    attr_accessor :solr_document, :current_ability
+    attr_accessor :solr_document, :current_ability, :request
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
-    def initialize(solr_document, current_ability)
+    # @param [ActionDispatch::Request] request the http request context
+    def initialize(solr_document, current_ability, request = nil)
       @solr_document = solr_document
       @current_ability = current_ability
+      @request = request
     end
 
     # CurationConcern methods

--- a/app/presenters/curation_concerns/presenter_factory.rb
+++ b/app/presenters/curation_concerns/presenter_factory.rb
@@ -3,18 +3,19 @@ module CurationConcerns
     class << self
       # @param [Array] ids the list of ids to load
       # @param [Class] klass the class of presenter to make
+      # @param [Array] args any other arguments to pass to the presenters
       # @return [Array] presenters for the documents in order of the ids
-      def build_presenters(ids, klass, ability)
-        new(ids, klass, ability).build
+      def build_presenters(ids, klass, *args)
+        new(ids, klass, *args).build
       end
     end
 
-    attr_reader :ids, :klass, :ability
+    attr_reader :ids, :klass, :args
 
-    def initialize(ids, klass, ability)
+    def initialize(ids, klass, *args)
       @ids = ids
       @klass = klass
-      @ability = ability
+      @args = args
     end
 
     def build
@@ -22,7 +23,7 @@ module CurationConcerns
       docs = load_docs
       ids.map do |id|
         solr_doc = docs.find { |doc| doc.id == id }
-        klass.new(solr_doc, ability) if solr_doc
+        klass.new(solr_doc, *args) if solr_doc
       end.compact
     end
 

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -64,17 +64,21 @@ module CurationConcerns
     def member_presenters(ids = ordered_ids, presenter_class = file_presenter_class)
       PresenterFactory.build_presenters(ids,
                                         presenter_class,
-                                        current_ability)
+                                        *presenter_factory_arguments)
     end
 
     # @return [Array<CollectionPresenter>] presenters for the collections that this work is a member of
     def collection_presenters
       PresenterFactory.build_presenters(in_collection_ids,
                                         collection_presenter_class,
-                                        current_ability)
+                                        *presenter_factory_arguments)
     end
 
     private
+
+      def presenter_factory_arguments
+        [current_ability]
+      end
 
       # @return [Array<String>] ids of the collections that this work is a member of
       def in_collection_ids

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -2,7 +2,7 @@ module CurationConcerns
   class WorkShowPresenter
     include ModelProxy
     include PresentsAttributes
-    attr_accessor :solr_document, :current_ability
+    attr_accessor :solr_document, :current_ability, :request
 
     class_attribute :collection_presenter_class, :file_presenter_class, :work_presenter_class
 
@@ -17,9 +17,11 @@ module CurationConcerns
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
-    def initialize(solr_document, current_ability)
+    # @param [ActionDispatch::Request] request the http request context
+    def initialize(solr_document, current_ability, request = nil)
       @solr_document = solr_document
       @current_ability = current_ability
+      @request = request
     end
 
     def page_title
@@ -77,7 +79,7 @@ module CurationConcerns
     private
 
       def presenter_factory_arguments
-        [current_ability]
+        [current_ability, request]
       end
 
       # @return [Array<String>] ids of the collections that this work is a member of

--- a/spec/presenters/curation_concerns/presenter_factory_spec.rb
+++ b/spec/presenters/curation_concerns/presenter_factory_spec.rb
@@ -30,7 +30,7 @@ describe CurationConcerns::PresenterFactory do
       let(:presenter_class) do
         Class.new(CurationConcerns::FileSetPresenter) do
           attr_reader :two, :three
-          def initialize(one, two, three)
+          def initialize(_one, two, three)
             @two = two
             @three = three
           end
@@ -41,7 +41,7 @@ describe CurationConcerns::PresenterFactory do
                                                  presenter_class,
                                                  'more',
                                                  'and more') }
-      it 'passes all the arguments' do 
+      it 'passes all the arguments' do
         expect(subject.first.two).to eq 'more'
         expect(subject.first.three).to eq 'and more'
       end

--- a/spec/presenters/curation_concerns/presenter_factory_spec.rb
+++ b/spec/presenters/curation_concerns/presenter_factory_spec.rb
@@ -25,5 +25,26 @@ describe CurationConcerns::PresenterFactory do
         expect(subject.size).to eq 1
       end
     end
+
+    context "with more arguments" do
+      let(:presenter_class) do
+        Class.new(CurationConcerns::FileSetPresenter) do
+          attr_reader :two, :three
+          def initialize(one, two, three)
+            @two = two
+            @three = three
+          end
+        end
+      end
+      let(:results) { [{ "id" => "12" }, { "id" => "13" }] }
+      subject { described_class.build_presenters(['12', '13'],
+                                                 presenter_class,
+                                                 'more',
+                                                 'and more') }
+      it 'passes all the arguments' do 
+        expect(subject.first.two).to eq 'more'
+        expect(subject.first.three).to eq 'and more'
+      end
+    end
   end
 end

--- a/spec/presenters/curation_concerns/work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/work_show_presenter_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe CurationConcerns::WorkShowPresenter do
   let(:solr_document) { SolrDocument.new(attributes) }
+  let(:request) { double }
   let(:date_value) { Date.today }
   let(:date_index) { date_value.to_s }
   let(:attributes) do
@@ -14,7 +15,7 @@ describe CurationConcerns::WorkShowPresenter do
   end
 
   let(:ability) { nil }
-  let(:presenter) { described_class.new(solr_document, ability) }
+  let(:presenter) { described_class.new(solr_document, ability, request) }
 
   describe "#to_s" do
     subject { presenter.to_s }
@@ -103,7 +104,7 @@ describe CurationConcerns::WorkShowPresenter do
 
       it "uses the set class" do
         expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
-          .with(['12', '33'], presenter_class, ability)
+          .with(['12', '33'], presenter_class, ability, request)
         presenter.file_set_presenters
       end
     end
@@ -118,7 +119,7 @@ describe CurationConcerns::WorkShowPresenter do
     end
     it "has a representative" do
       expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
-        .with([obj.members[0].id], presenter_class, ability).and_return ["abc"]
+        .with([obj.members[0].id], presenter_class, ability, request).and_return ["abc"]
       expect(presenter.representative_presenter).to eq("abc")
     end
   end


### PR DESCRIPTION
This enables presenters to use the request context for things such as building urls (using request.host)

@projecthydra/sufia-code-reviewers
