### PR TITLE
Always use Default queue.

### DIFF
--- a/lib/curation_concerns/configuration.rb
+++ b/lib/curation_concerns/configuration.rb
@@ -131,7 +131,7 @@ module CurationConcerns
     #   ActiveJob queue to handle ingest-like jobs.
     attr_writer :ingest_queue_name
     def ingest_queue_name
-      @ingest_queue_name ||= :ingest
+      @ingest_queue_name ||= :default
     end
 
     callback.enable :after_create_concern, :after_create_fileset,


### PR DESCRIPTION
Closes #790 

Configuration of the queues can be done in an initializer if necessary.
CC config lets you change all the ingest queues in one place.