### PR TITLE
Refactor ImportUrlJob to use BrowseEverything::Retriever

### DIFF
--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rdf', '~> 1.99'
   spec.add_dependency 'rdf-vocab', '~> 0'
   spec.add_dependency 'awesome_nested_set', '~> 3.0'
+  spec.add_dependency 'browse-everything', '~> 0.10'
 
   spec.add_development_dependency 'solr_wrapper', '~> 0.4'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
@@ -58,5 +59,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'jasmine'
   spec.add_development_dependency 'rubocop', '~> 0.39'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.4.1'
+  spec.add_development_dependency 'webmock'
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@ Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = ENV['TRAVIS'] ? 30 : 15
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'webmock/rspec'
+WebMock.allow_net_connect!
 
 $in_travis = !ENV['TRAVIS'].nil? && ENV['TRAVIS'] == 'true'
 


### PR DESCRIPTION
Fixes #726 

This change is interface-compatible with the old `ImportURLJob` implementation, but ignores some of `BrowseEverything::Retriever`’s extended functionality (like respecting expiration dates on single use links and extra auth headers that some cloud providers require). IOW, it’s a regular file downloader that uses a `BrowseEverything` component, but not a full implementation of what it takes to retrieve from all `BrowseEverything` sources.

Changes proposed in this pull request:
* Replace the hand-rolled `Net::HTTP` downloader with `BrowseEverything::Retriever#retrieve`
* Replace direct HTTP request mocking in the spec test with `WebMock`

@projecthydra/sufia-code-reviewers

