### PR TITLE
Fix inactive rights editing bug

### DIFF
--- a/app/assets/javascripts/curation_concerns/curation_concerns.js
+++ b/app/assets/javascripts/curation_concerns/curation_concerns.js
@@ -8,7 +8,7 @@
 //= require curation_concerns/file_manager/member
 //= require curation_concerns/batch_select
 //= require curation_concerns/collections
-
+//= require curation_concerns/rights
 
 // Initialize plugins and Bootstrap dropdowns on jQuery's ready event as well as
 // Turbolinks's page change event.

--- a/app/assets/javascripts/curation_concerns/rights.js
+++ b/app/assets/javascripts/curation_concerns/rights.js
@@ -1,0 +1,8 @@
+Blacklight.onLoad(function () {
+  $('.force-select').each(function(){
+    if ($(this).data('force-value')){
+      var option = $('<option>', { value: $(this).data('force-value'), text: $(this).data('force-label')});
+      $(this).append($(option).attr('selected','selected'));
+    }
+  });
+});

--- a/app/inputs/select_with_modal_help_input.rb
+++ b/app/inputs/select_with_modal_help_input.rb
@@ -31,6 +31,16 @@ class SelectWithModalHelpInput < MultiValueWithHelpInput
       @rendered_first_element = true
 
       html_options.merge!(options.slice(:include_blank))
+      html_options = add_force_option_data_to_html_options(value, html_options)
       template.select_tag(attribute_name, template.options_for_select(select_options, value), html_options)
+    end
+
+    def add_force_option_data_to_html_options(value, html_options)
+      return html_options if value.blank? || RightsService.active?(value)
+      html_options.tap do |opts|
+        opts[:class] << ' force-select'
+        opts[:'data-force-label'] = RightsService.label(value)
+        opts[:'data-force-value'] = value
+      end
     end
 end

--- a/app/services/rights_service.rb
+++ b/app/services/rights_service.rb
@@ -2,8 +2,22 @@ module RightsService
   mattr_accessor :authority
   self.authority = Qa::Authorities::Local.subauthority_for('rights')
 
-  def self.select_options
+  def self.select_all_options
+    authority.all.map do |element|
+      [element[:label], element[:id]]
+    end
+  end
+
+  def self.select_active_options
     active_elements.map { |e| [e[:label], e[:id]] }
+  end
+
+  def self.active?(id)
+    authority.find(id).fetch('active')
+  end
+
+  def self.select_inactive_options
+    inactive_elements.map { |e| [e[:label], e[:id]] }
   end
 
   def self.label(id)
@@ -12,5 +26,9 @@ module RightsService
 
   def self.active_elements
     authority.all.select { |e| authority.find(e[:id])[:active] }
+  end
+
+  def self.inactive_elements
+    authority.all.select { |e| authority.find(e[:id])[:active] == false }
   end
 end

--- a/app/views/curation_concerns/base/_form_rights.html.erb
+++ b/app/views/curation_concerns/base/_form_rights.html.erb
@@ -10,7 +10,7 @@
       </p>
 
       <%= f.input :rights, as: :select,
-        collection: RightsService.select_options,
+        collection: RightsService.select_active_options,
         input_html: { class: 'form-control' } %>
     </fieldset>
   </div>

--- a/spec/inputs/select_with_modal_help_input_spec.rb
+++ b/spec/inputs/select_with_modal_help_input_spec.rb
@@ -1,9 +1,14 @@
 require 'spec_helper'
 
 describe 'SelectWithModalHelpInput', type: :input do
+  before do
+    qa_fixtures = { local_path: File.expand_path('../../fixtures/authorities', __FILE__) }
+    stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
+  end
+
   subject { input_for file, :rights, options }
   let(:file) { FileSet.new }
-  let(:base_options) { { as: :select_with_modal_help, required: true, collection: RightsService.select_options } }
+  let(:base_options) { { as: :select_with_modal_help, required: true, collection: RightsService.select_active_options } }
   let(:options) { base_options }
 
   context "when a blank is requested" do
@@ -15,7 +20,27 @@ describe 'SelectWithModalHelpInput', type: :input do
 
   context "when a blank is not requested" do
     it 'has no blanks' do
-      expect(subject).to have_selector 'select option:first-child', text: 'Attribution 3.0 United States'
+      expect(subject).to have_selector 'select option:first-child', text: 'First Active Term'
+    end
+  end
+
+  context "when inactive rights are associated with a work" do
+    before do
+      file.rights = ['demo_id_04']
+    end
+
+    it 'will attach an option with a data-attribute of force-label' do
+      expect(subject).to have_xpath('//select[1][@data-force-label="Fourth is an Inactive Term"]')
+      expect(subject).not_to have_xpath('//select[2][@data-force-label="Fourth is an Inactive Term"]')
+    end
+
+    it 'will attach an option with a data-attribute of force-value' do
+      expect(subject).to have_xpath('//select[1][@data-force-value="demo_id_04"]')
+      expect(subject).not_to have_xpath('//select[2][@data-force-value="demo_id_04"]')
+    end
+
+    it 'will attach an option with a class of inactive-rights' do
+      expect(subject).to have_css 'select.force-select'
     end
   end
 end

--- a/spec/services/rights_service_spec.rb
+++ b/spec/services/rights_service_spec.rb
@@ -7,13 +7,29 @@ describe RightsService do
     stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
   end
 
-  describe "#select_options" do
+  describe "#select_active_options" do
     it "returns active terms" do
-      expect(described_class.select_options).to include(["First Active Term", "demo_id_01"], ["Second Active Term", "demo_id_02"])
+      expect(described_class.select_active_options).to include(["First Active Term", "demo_id_01"], ["Second Active Term", "demo_id_02"])
     end
 
     it "does not return inactive terms" do
-      expect(described_class.select_options).not_to include(["Third is an Inactive Term", "demo_id_03"], ["Fourth is an Inactive Term", "demo_id_04"])
+      expect(described_class.select_active_options).not_to include(["Third is an Inactive Term", "demo_id_03"], ["Fourth is an Inactive Term", "demo_id_04"])
+    end
+  end
+
+  describe "#select_inactive_options" do
+    it "returns inactive terms" do
+      expect(described_class.select_inactive_options).to include(["Fourth is an Inactive Term", "demo_id_04"])
+    end
+
+    it "does not return active terms" do
+      expect(described_class.select_inactive_options).not_to include(["First Active Term", "demo_id_01"])
+    end
+  end
+
+  describe "#select_all_options" do
+    it "returns both active and inactive terms" do
+      expect(described_class.select_all_options).to include(["Fourth is an Inactive Term", "demo_id_04"], ["First Active Term", "demo_id_01"])
     end
   end
 


### PR DESCRIPTION
Fixes #775 

Creates an html select option containing data-attributes with the work's inactive rights, which the javascript then uses to add as options into the work edit form's rights remove selects. The user can save their edits without altering their rights or remove the inactive ones.


Changes proposed in this pull request:
* the addition of data-attributes and classes to the html that is used to create rights selectors
* the addition of javascript that looks for those attributes and classes and creates options for the work's inactive rights, with a class on the options to be used at the app level to indicate the rights are inactive (if desired)

@projecthydra/sufia-code-reviewers
