### PR TITLE
Save file and reindex file set when characterizing

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -6,7 +6,8 @@ class CharacterizeJob < ActiveJob::Base
   def perform(file_set, filename)
     raise LoadError, "#{file_set.class.characterization_proxy} was not found" unless file_set.characterization_proxy?
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
-    file_set.save!
+    file_set.characterization_proxy.save!
+    file_set.update_index
     CreateDerivativesJob.perform_later(file_set, filename)
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -16,7 +16,8 @@ describe CharacterizeJob do
   context 'when the characterization proxy content is present' do
     it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
       expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
-      expect(file_set).to receive(:save!)
+      expect(file).to receive(:save!)
+      expect(file_set).to receive(:update_index)
       expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, filename)
       described_class.perform_now(file_set, filename)
     end


### PR DESCRIPTION
The characterization metadata is not being saved after it is extracted and written to the file's metadata node.