### PR TITLE
Fix inactive rights editing bug, Take two

### DIFF
--- a/app/helpers/curation_concerns/main_app_helpers.rb
+++ b/app/helpers/curation_concerns/main_app_helpers.rb
@@ -9,4 +9,5 @@ module CurationConcerns::MainAppHelpers
   include CurationConcerns::LeaseHelper
   include CurationConcerns::CollectionsHelper
   include CurationConcerns::PermissionsHelper
+  include CurationConcerns::RightsHelper
 end

--- a/app/helpers/curation_concerns/rights_helper.rb
+++ b/app/helpers/curation_concerns/rights_helper.rb
@@ -1,0 +1,9 @@
+module CurationConcerns::RightsHelper
+  def include_current_value(value, _index, render_options, html_options)
+    unless value.blank? || RightsService.active?(value)
+      html_options[:class] << ' force-select'
+      render_options += [[RightsService.label(value), value]]
+    end
+    [render_options, html_options]
+  end
+end

--- a/app/inputs/multi_value_select_input.rb
+++ b/app/inputs/multi_value_select_input.rb
@@ -1,0 +1,45 @@
+class MultiValueSelectInput < MultiValueInput
+  def input_type
+    'multi_value'.freeze
+  end
+
+  private
+
+    def select_options
+      @select_options ||= begin
+        collection = options.delete(:collection) || self.class.boolean_collection
+        collection.respond_to?(:call) ? collection.call : collection.to_a
+      end
+    end
+
+    def build_field_options(value)
+      field_options = input_html_options.dup
+
+      field_options[:value] = value
+      if @rendered_first_element
+        field_options[:id] = nil
+        field_options[:required] = nil
+      else
+        field_options[:id] ||= input_dom_id
+      end
+      field_options[:class] ||= []
+      field_options[:class] += ["#{input_dom_id} form-control multi-text-field"]
+      field_options[:'aria-labelledby'] = label_id
+      field_options.delete(:multiple)
+      field_options.delete(:item_helper)
+      field_options.merge!(options.slice(:include_blank))
+
+      @rendered_first_element = true
+
+      field_options
+    end
+
+    def build_field(value, index)
+      render_options = select_options
+      html_options = build_field_options(value)
+      if options[:item_helper]
+        (render_options, html_options) = options[:item_helper].call(value, index, render_options, html_options)
+      end
+      template.select_tag(attribute_name, template.options_for_select(render_options, value), html_options)
+    end
+end

--- a/app/services/rights_service.rb
+++ b/app/services/rights_service.rb
@@ -2,8 +2,18 @@ module RightsService
   mattr_accessor :authority
   self.authority = Qa::Authorities::Local.subauthority_for('rights')
 
-  def self.select_options
+  def self.select_all_options
+    authority.all.map do |element|
+      [element[:label], element[:id]]
+    end
+  end
+
+  def self.select_active_options
     active_elements.map { |e| [e[:label], e[:id]] }
+  end
+
+  def self.active?(id)
+    authority.find(id).fetch('active')
   end
 
   def self.label(id)

--- a/app/views/curation_concerns/base/_form_rights.html.erb
+++ b/app/views/curation_concerns/base/_form_rights.html.erb
@@ -9,8 +9,10 @@
         <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which license to choose.
       </p>
 
-      <%= f.input :rights, as: :select,
-        collection: RightsService.select_options,
+      <%= f.input :rights, as: :multi_value_select,
+        collection: RightsService.select_active_options,
+        include_blank: true,
+        item_helper: method(:include_current_value),
         input_html: { class: 'form-control' } %>
     </fieldset>
   </div>

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,5 +1,5 @@
 <% if f.object.class.multiple? key %>
-  <%= f.input key, as: :multi_value_with_help, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
 <% else %>
   <%= f.input key, required: f.object.required?(key) %>
 <% end %>

--- a/spec/services/rights_service_spec.rb
+++ b/spec/services/rights_service_spec.rb
@@ -7,13 +7,19 @@ describe RightsService do
     stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
   end
 
-  describe "#select_options" do
+  describe "#select_active_options" do
     it "returns active terms" do
-      expect(described_class.select_options).to include(["First Active Term", "demo_id_01"], ["Second Active Term", "demo_id_02"])
+      expect(described_class.select_active_options).to include(["First Active Term", "demo_id_01"], ["Second Active Term", "demo_id_02"])
     end
 
     it "does not return inactive terms" do
-      expect(described_class.select_options).not_to include(["Third is an Inactive Term", "demo_id_03"], ["Fourth is an Inactive Term", "demo_id_04"])
+      expect(described_class.select_active_options).not_to include(["Third is an Inactive Term", "demo_id_03"], ["Fourth is an Inactive Term", "demo_id_04"])
+    end
+  end
+
+  describe "#select_all_options" do
+    it "returns both active and inactive terms" do
+      expect(described_class.select_all_options).to include(["Fourth is an Inactive Term", "demo_id_04"], ["First Active Term", "demo_id_01"])
     end
   end
 

--- a/spec/views/curation_concerns/base/_form_rights_spec.rb
+++ b/spec/views/curation_concerns/base/_form_rights_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'curation_concerns/base/_form_rights.html.erb' do
+  let(:curation_concern) { GenericWork.new }
+  let(:form) { CurationConcerns::Forms::WorkForm.new(curation_concern, nil) }
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "curation_concerns/base/form_rights", f: f, curation_concern: curation_concern %>
+      <% end %>
+    )
+  end
+
+  before do
+    qa_fixtures = { local_path: File.expand_path('../../../../fixtures/authorities', __FILE__) }
+    stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
+  end
+
+  context "when active and inactive rights are associated with a work" do
+    before do
+      curation_concern.rights = ['demo_id_01', 'demo_id_04']
+      assign(:form, form)
+      render inline: form_template, locals: { curation_concern: curation_concern }
+    end
+
+    it 'will only include active values if the current value is active' do
+      expect(rendered).not_to have_xpath('//div/ul/li[1]/select/option[@value="demo_id_04"]')
+      expect(rendered).not_to have_xpath('//div/ul/li[1]/select/option[text()="Fourth is an Inactive Term"]')
+    end
+
+    it 'will always include the current value as an option' do
+      expect(rendered).to have_xpath('//div/ul/li[2]/select/option[@value="demo_id_04" and @selected="selected"]')
+      expect(rendered).to have_xpath('//div/ul/li[2]/select/option[text()="Fourth is an Inactive Term"]')
+    end
+
+    it 'only offers active values to add to a work' do
+      expect(rendered).not_to have_xpath('//div/ul/li[3]/select/option[@value="demo_id_04"]')
+      expect(rendered).not_to have_xpath('//div/ul/li[3]/select/option[text()="Fourth is an Inactive Term"]')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #775 ; refs #811 and #812

Allows a user to save their edits without altering their rights or removing the inactive ones.

Changes proposed in this pull request:

* the addition of a `MultiValueSelectInput` input class that presents individual drop-down select elements for multi-valued fields 
* the addition of a helper that ensures that current values are always selectable, even if marked inactive by the controlling authority

@projecthydra/sufia-code-reviewers