### PR TITLE
Improved UI for required field labels

### DIFF
--- a/app/assets/stylesheets/curation_concerns/modules/forms.scss
+++ b/app/assets/stylesheets/curation_concerns/modules/forms.scss
@@ -78,3 +78,7 @@ form {
 form.button-to {
   margin:0 .3em;
 }
+
+.required-tag {
+  vertical-align: super;
+}

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -159,6 +159,8 @@ en:
   file_manager:
     link_text: 'File Manager'
   simple_form:
+    required:
+      html: '<span class="label label-info required-tag">required</span>'
     hints:
       defaults:
         description: 'Please keep your description to 300 words or fewer.'

--- a/lib/generators/curation_concerns/templates/config/initializers/simple_form.rb
+++ b/lib/generators/curation_concerns/templates/config/initializers/simple_form.rb
@@ -102,7 +102,7 @@ SimpleForm.setup do |config|
   # config.item_wrapper_class = nil
 
   # How the label text should be generated altogether with the required text.
-  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+  config.label_text = ->(label, required, _) { "#{label} #{required}" }
 
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil


### PR DESCRIPTION
Before:
<img width="565" alt="screen shot 2016-05-26 at 10 01 01 am" src="https://cloud.githubusercontent.com/assets/1678665/15577039/d228b454-2328-11e6-9dfc-9bc7245cd3cf.png">

After:
<img width="569" alt="screen shot 2016-05-24 at 10 28 51 am" src="https://cloud.githubusercontent.com/assets/1678665/15576932/583d7d32-2328-11e6-8041-8f468e5d5e64.png">

Related discussion: https://github.com/projecthydra/sufia/issues/2076