### PR TITLE
Add FacetedAttributeRenderer

### DIFF
--- a/app/renderers/curation_concerns/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/curation_concerns/renderers/faceted_attribute_renderer.rb
@@ -1,0 +1,19 @@
+module CurationConcerns
+  module Renderers
+    class FacetedAttributeRenderer < AttributeRenderer
+      private
+
+        def li_value(value)
+          link_to(ERB::Util.h(value), search_path(value))
+        end
+
+        def search_path(value)
+          Rails.application.routes.url_helpers.search_catalog_path(:"f[#{search_field}][]" => ERB::Util.h(value))
+        end
+
+        def search_field
+          ERB::Util.h(Solrizer.solr_name(options.fetch(:search_field, field), :facetable, type: :string))
+        end
+    end
+  end
+end

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,7 +1,7 @@
   <%= presenter.attribute_to_html(:description) %>
-  <%= presenter.attribute_to_html(:creator, catalog_search_link: true ) %>
-  <%= presenter.attribute_to_html(:contributor, label: 'Contributors', catalog_search_link: true) %>
-  <%= presenter.attribute_to_html(:subject, catalog_search_link: true) %>
+  <%= presenter.attribute_to_html(:creator, render_as: :linked) %>
+  <%= presenter.attribute_to_html(:contributor, label: 'Contributors', render_as: :linked) %>
+  <%= presenter.attribute_to_html(:subject, render_as: :linked) %>
   <%= presenter.attribute_to_html(:publisher) %>
   <%= presenter.attribute_to_html(:language) %>
 

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -8,6 +8,6 @@
     <%= presenter.attribute_to_html(:permission_badge, label: 'Visibility') %>
     <%= presenter.attribute_to_html(:embargo_release_date) %>
     <%= presenter.attribute_to_html(:lease_expiration_date) %>
-    <%= presenter.attribute_to_html(:rights) %>
+    <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
   </tbody>
 </table>

--- a/spec/renderers/curation_concerns/renderers/faceted_attribute_renderer_spec.rb
+++ b/spec/renderers/curation_concerns/renderers/faceted_attribute_renderer_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe CurationConcerns::Renderers::FacetedAttributeRenderer do
+  let(:field) { :name }
+  let(:renderer) { described_class.new(field, ['Bob', 'Jessica']) }
+
+  describe "#attribute_to_html" do
+    subject { Nokogiri::HTML(renderer.render) }
+    let(:expected) { Nokogiri::HTML(tr_content) }
+
+    let(:tr_content) {%(
+      <tr><th>Name</th>
+      <td><ul class='tabular'>
+      <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">Bob</a></li>
+      <li class="attribute name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">Jessica</a></li>
+      </ul></td></tr>
+    )}
+    it { expect(renderer).not_to be_microdata(field) }
+    it { expect(subject).to be_equivalent_to(expected) }
+  end
+end


### PR DESCRIPTION
Prerequisite for fixing [#2081@sufia](https://github.com/projecthydra/sufia/issues/2081)

Add a `FacetedAttributeRenderer` to generate facet-type linked attributes

The `LinkedAttributeRenderer` generates links in the `/catalog?q=value&search_field=field_name` format. These links don't work with Sufia's default configuration. The faceted link type (`/catalog?f[field_name][]=value`) does work.

Changes proposed in this pull request:
* Add `FacetedAttributeRenderer` to generate the new link types
* Update `PresentsAttributes` to accept a `:render_as` option for more flexible specification of which attribute renderer to use

@projecthydra/sufia-code-reviewers

