### PR TITLE
Keep solr_document logic out of the presenter

### DIFF
--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -21,17 +21,17 @@ module CurationConcerns
     delegate :has?, :first, :fetch, to: :solr_document
 
     # Metadata Methods
-    delegate :title, :description, :creator, :contributor, :subject, :publisher,
-             :language, :date_uploaded, :rights,
+    delegate :title, :label, :description, :creator, :contributor, :subject,
+             :publisher, :language, :date_uploaded, :rights,
              :embargo_release_date, :lease_expiration_date,
              :depositor, :keyword, :title_or_label, to: :solr_document
 
     def page_title
-      Array.wrap(solr_document['label_tesim']).first
+      label
     end
 
     def link_name
-      current_ability.can?(:read, id) ? Array.wrap(solr_document['label_tesim']).first : 'File'
+      current_ability.can?(:read, id) ? label : 'File'
     end
   end
 end

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -25,7 +25,7 @@ module CurationConcerns
     end
 
     def page_title
-      solr_document.title.first
+      title.first
     end
 
     # CurationConcern methods

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -4,8 +4,9 @@ describe CurationConcerns::FileSetPresenter do
   let(:solr_document) { SolrDocument.new("title_tesim" => ["foo bar"],
                                          "human_readable_type_tesim" => ["File Set"],
                                          "mime_type_ssi" => 'image/jpeg',
+                                         'label_tesim' => ['one', 'two'],
                                          "has_model_ssim" => ["FileSet"]) }
-  let(:ability) { nil }
+  let(:ability) { double }
   let(:presenter) { described_class.new(solr_document, ability) }
 
   describe "#to_s" do
@@ -61,6 +62,19 @@ describe CurationConcerns::FileSetPresenter do
     it "delegates to the solr_document" do
       expect(solr_document).to receive(:fetch).and_call_original
       expect(presenter.fetch("has_model_ssim")).to eq ["FileSet"]
+    end
+  end
+
+  describe "#link_name" do
+    subject { presenter.link_name }
+    context "when it's readable" do
+      before { allow(ability).to receive(:can?).and_return(true) }
+      it { is_expected.to eq 'one' }
+    end
+
+    context "when it's not readable" do
+      before { allow(ability).to receive(:can?).and_return(false) }
+      it { is_expected.to eq 'File' }
     end
   end
 end

--- a/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
         id: "test",
         title_tesim: "Test",
         thumbnail_path_ss: "/test/image/path.jpg",
-        label_tesim: "file_name.tif"
+        label_tesim: ["file_name.tif"]
       )
     )
   end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Only the solr_document class should be aware of the name of the solr
fields.