### PR TITLE
Improved Bootstrap theme color contrast

### DIFF
--- a/app/assets/stylesheets/curation_concerns.scss
+++ b/app/assets/stylesheets/curation_concerns.scss
@@ -1,3 +1,4 @@
+@import 'curation_concerns/colors';
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 

--- a/app/assets/stylesheets/curation_concerns/_colors.scss
+++ b/app/assets/stylesheets/curation_concerns/_colors.scss
@@ -1,0 +1,16 @@
+//
+// Colors
+//
+// Many of the default Bootstrap theme colors
+// fail to meet WCAG AA color contrast standards.
+// These new variables at a minimum meet a 3:1
+// contrast ratio (which is ideal for large text).
+//
+//                          Contrast ratio as
+//                          foreground to #fff
+
+$brand-primary: #0275d8;    // 4.63:1
+$brand-success: #00ac07;    // 3.04:1
+$brand-info:    #17a0d3;    // 3:1
+$brand-warning: #d58000;    // 3.04:1
+$brand-danger:  #d9534f;    // 3.96:1


### PR DESCRIPTION
Fixes https://github.com/projecthydra/sufia/issues/2091; ref https://github.com/projecthydra/sufia/issues/2076

Many of the Bootstrap theme colors we use fail to meet WCAG AA color contrast standards.

![](https://cloud.githubusercontent.com/assets/895831/14399925/c984f222-fde9-11e5-9a54-583a44d7d378.png)

Using colors from this Bootstrap PR: https://github.com/twbs/bootstrap/pull/19693

