### PR TITLE
Extract WorkingDirectory class

### DIFF
--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -2,11 +2,12 @@ class CreateDerivativesJob < ActiveJob::Base
   queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
-  # @param [String] file_name
-  def perform(file_set, file_name)
+  # @param [String] file_id identifier for a Hydra::PCDM::File
+  def perform(file_set, file_id)
     return if file_set.video? && !CurationConcerns.config.enable_ffmpeg
+    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
 
-    file_set.create_derivatives(file_name)
+    file_set.create_derivatives(filename)
     # The thumbnail is indexed in the solr document, so reindex
     file_set.update_index
     file_set.parent.update_index if parent_needs_reindex?(file_set)

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -2,28 +2,36 @@ class IngestFileJob < ActiveJob::Base
   queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
-  # @param [String] filename
+  # @param [String] filename the cached file within the CurationConcerns.config.working_path
   # @param [String,NilClass] mime_type
   # @param [User] user
   # @param [String] relation ('original_file')
   def perform(file_set, filename, mime_type, user, relation = 'original_file')
-    file = File.open(filename, "rb")
+    local_file = File.open(filename, "rb")
     # If mime-type is known, wrap in an IO decorator
     # Otherwise allow Hydra::Works service to determine mime_type
     if mime_type
-      file = Hydra::Derivatives::IoDecorator.new(file)
-      file.mime_type = mime_type
-      file.original_name = File.basename(filename)
+      local_file = Hydra::Derivatives::IoDecorator.new(local_file)
+      local_file.mime_type = mime_type
+      local_file.original_name = File.basename(filename)
     end
 
     # Tell AddFileToFileSet service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
-    Hydra::Works::AddFileToFileSet.call(file_set, file, relation.to_sym, versioning: false)
+    Hydra::Works::AddFileToFileSet.call(file_set,
+                                        local_file,
+                                        relation.to_sym,
+                                        versioning: false)
 
     # Persist changes to the file_set
     file_set.save!
 
+    repository_file = file_set.send(relation.to_sym)
+
     # Do post file ingest actions
-    CurationConcerns::VersioningService.create(file_set.send(relation.to_sym), user)
-    CharacterizeJob.perform_later(file_set, filename)
+    CurationConcerns::VersioningService.create(repository_file, user)
+
+    # TODO: this is a problem, the file may not be available at this path on another machine.
+    # It may be local, or it may be in s3
+    CharacterizeJob.perform_later(file_set, repository_file.id)
   end
 end

--- a/app/services/curation_concerns/working_directory.rb
+++ b/app/services/curation_concerns/working_directory.rb
@@ -1,0 +1,48 @@
+module CurationConcerns
+  module WorkingDirectory
+    class << self
+      # @param [String] repository_file_id identifier for Hydra::PCDM::File
+      # @param [String] id the identifier of the FileSet
+      # @return [String] path of the working file
+      def find_or_retrieve(repository_file_id, id)
+        repository_file = Hydra::PCDM::File.find(repository_file_id)
+        working_path = full_filename(id, repository_file.original_name)
+        return working_path if File.exist?(working_path)
+        copy_repository_resource_to_working_directory(repository_file, id)
+      end
+
+      # @param [File, ActionDispatch::Http::UploadedFile] file
+      # @param [String] id the identifier of the FileSet
+      # @return [String] path of the working file
+      def copy_file_to_working_directory(file, id)
+        file_name = file.respond_to?(:original_filename) ? file.original_filename : ::File.basename(file)
+        copy_stream_to_working_directory(id, file_name, file)
+      end
+
+      # @param [ActiveFedora::File] file the resource in the repo
+      # @return [String] path of the working file
+      def copy_repository_resource_to_working_directory(file, id)
+        # TODO: this causes a load into memory, which we'd like to avoid
+        copy_stream_to_working_directory(id, file.original_name, StringIO.new(file.content))
+      end
+
+      private
+
+        # @param [String] id the identifier
+        # @param [String] name the file name
+        # @param [#read] stream the stream to copy to the working directory
+        # @return [String] path of the working file
+        def copy_stream_to_working_directory(id, name, stream)
+          working_path = full_filename(id, name)
+          FileUtils.mkdir_p(File.dirname(working_path))
+          IO.copy_stream(stream, working_path)
+          working_path
+        end
+
+        def full_filename(id, original_name)
+          pair = id.scan(/..?/).first(4)
+          File.join(CurationConcerns.config.working_path, *pair, original_name)
+        end
+    end
+  end
+end

--- a/spec/actors/curation_concerns/file_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_actor_spec.rb
@@ -21,14 +21,16 @@ describe CurationConcerns::Actors::FileActor do
     let(:revision_id)      { 'asdf1234' }
     let(:previous_version) { mock_file_factory }
     let(:file_path)        { 'path/to/working_file' }
+
     before do
       allow(file_set).to receive(:remastered).and_return(previous_version)
       allow(previous_version).to receive(:restore_version).with(revision_id)
       allow(previous_version).to receive(:original_name).and_return('original_name')
     end
+
     it 'reverts to a previous version of a file' do
       expect(CurationConcerns::VersioningService).to receive(:create).with(previous_version, user)
-      expect(actor).to receive(:copy_repository_resource_to_working_directory).with(previous_version).and_return(file_path)
+      expect(CurationConcerns::WorkingDirectory).to receive(:copy_repository_resource_to_working_directory).with(previous_version, file_set.id).and_return(file_path)
       expect(CharacterizeJob).to receive(:perform_later).with(file_set, file_path)
       actor.revert_to(revision_id)
     end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CurationConcerns::CreateDerivativesJob do
+describe CreateDerivativesJob do
   let(:id) { '123' }
 
   before do
@@ -9,6 +9,14 @@ describe CurationConcerns::CreateDerivativesJob do
     allow(FileSet).to receive(:find).with(id).and_return(file_set)
     allow(file_set).to receive(:mime_type).and_return('audio/x-wav')
     allow(file_set).to receive(:id).and_return(id)
+  end
+
+  let(:file) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = 'picture.png'
+      f.save!
+    end
   end
 
   let(:file_set) { FileSet.new }
@@ -21,7 +29,7 @@ describe CurationConcerns::CreateDerivativesJob do
     it 'calls create_derivatives and save on a file set' do
       expect(Hydra::Derivatives::AudioDerivatives).to receive(:create)
       expect(file_set).to receive(:update_index)
-      CreateDerivativesJob.perform_now(file_set, 'spec/fixtures/piano_note.wav')
+      described_class.perform_now(file_set, file.id)
     end
   end
 
@@ -37,7 +45,7 @@ describe CurationConcerns::CreateDerivativesJob do
 
       it 'updates the index of the parent object' do
         expect(parent).to receive(:update_index)
-        CreateDerivativesJob.perform_now(file_set, 'spec/fixtures/piano_note.wav')
+        described_class.perform_now(file_set, file.id)
       end
     end
 
@@ -46,7 +54,7 @@ describe CurationConcerns::CreateDerivativesJob do
 
       it "doesn't update the parent's index" do
         expect(parent).to_not receive(:update_index)
-        CreateDerivativesJob.perform_now(file_set, 'spec/fixtures/piano_note.wav')
+        described_class.perform_now(file_set, file.id)
       end
     end
   end

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -20,7 +20,7 @@ describe IngestFileJob do
       Object.send(:remove_const, :FileSetWithExtras)
     end
     it 'uses the provided relationship' do
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, filename)
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String)
       described_class.perform_now(file_set, filename, 'image/png', 'bob', 'remastered')
       expect(file_set.reload.remastered.mime_type).to eq 'image/png'
     end
@@ -28,7 +28,7 @@ describe IngestFileJob do
 
   context 'when given a mime_type' do
     it 'uses the provided mime_type' do
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, filename)
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String)
       described_class.perform_now(file_set, filename, 'image/png', 'bob')
       expect(file_set.reload.original_file.mime_type).to eq 'image/png'
     end
@@ -39,8 +39,8 @@ describe IngestFileJob do
       # Mocking CC Versioning here as it will be the versioning machinery called by the job.
       # The parameter versioning: false instructs the machinery in Hydra::Works NOT to do versioning. So it can be handled later on.
       allow(CurationConcerns::VersioningService).to receive(:create)
-      expect(Hydra::Works::AddFileToFileSet).to receive(:call).with(file_set, instance_of(::File), :original_file, versioning: false)
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, filename)
+      expect(Hydra::Works::AddFileToFileSet).to receive(:call).with(file_set, instance_of(::File), :original_file, versioning: false).and_call_original
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String)
       described_class.perform_now(file_set, filename, nil, 'bob')
     end
   end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This enables CharacterizeJob and CreateDerivativesJob not to have
to be run on the same filesystem that the webapp is on. However,
it won't have to pull the file across the network if the file is local.