### PR TITLE
Contextual Nested Works

### DIFF
--- a/app/actors/curation_concerns/actors/add_to_work_actor.rb
+++ b/app/actors/curation_concerns/actors/add_to_work_actor.rb
@@ -1,0 +1,35 @@
+module CurationConcerns
+  module Actors
+    class AddToWorkActor < AbstractActor
+      def create(attributes)
+        work_ids = attributes.delete(:in_works_ids)
+        next_actor.create(attributes) && add_to_works(work_ids)
+      end
+
+      def update(attributes)
+        work_ids = attributes.delete(:in_works_ids)
+        add_to_works(work_ids) && next_actor.update(attributes)
+      end
+
+      private
+
+        def add_to_works(new_work_ids)
+          return true unless new_work_ids.present?
+          (curation_concern.in_works_ids - new_work_ids).each do |old_id|
+            work = ::ActiveFedora::Base.find(old_id)
+            work.ordered_members.delete(curation_concern)
+            work.members.delete(curation_concern)
+            work.save
+          end
+
+          # add to new
+          (new_work_ids - curation_concern.in_works_ids).each do |work_id|
+            work = ::ActiveFedora::Base.find(work_id)
+            work.ordered_members << curation_concern
+            work.save
+          end
+          true
+        end
+    end
+  end
+end

--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -7,7 +7,7 @@ module CurationConcerns
       delegate :human_readable_type, :open_access?, :authenticated_only_access?,
                :open_access_with_embargo_release_date?, :private_access?,
                :embargo_release_date, :lease_expiration_date, :member_ids,
-               :visibility, to: :model
+               :visibility, :in_works_ids, to: :model
 
       self.terms = [:title, :creator, :contributor, :description,
                     :keyword, :rights, :publisher, :date_created, :subject, :language,
@@ -15,7 +15,7 @@ module CurationConcerns
                     :representative_id, :thumbnail_id, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
-                    :visibility, :ordered_member_ids, :source]
+                    :visibility, :ordered_member_ids, :source, :in_works_ids]
 
       self.required_fields = [:title]
 
@@ -42,8 +42,14 @@ module CurationConcerns
         # This determines whether the allowed parameters are single or multiple.
         # By default it delegates to the model.
         def multiple?(term)
-          return true if term.to_s == 'ordered_member_ids'
-          super
+          case term.to_s
+          when 'ordered_member_ids'
+            true
+          when 'in_works_ids'
+            true
+          else
+            super
+          end
         end
 
         # Overriden to cast 'rights' to an array

--- a/app/models/concerns/curation_concerns/nested_works.rb
+++ b/app/models/concerns/curation_concerns/nested_works.rb
@@ -1,0 +1,14 @@
+module CurationConcerns
+  module NestedWorks
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :valid_child_concerns
+      self.valid_child_concerns = CurationConcerns::ClassifyConcern.new.all_curation_concern_classes
+    end
+
+    def in_works_ids
+      in_works.map(&:id)
+    end
+  end
+end

--- a/app/models/concerns/curation_concerns/work_behavior.rb
+++ b/app/models/concerns/curation_concerns/work_behavior.rb
@@ -14,6 +14,7 @@ module CurationConcerns::WorkBehavior
   include CurationConcerns::RequiredMetadata
   include Hydra::AccessControls::Embargoable
   include GlobalID::Identification
+  include CurationConcerns::NestedWorks
 
   included do
     property :owner, predicate: RDF::URI.new('http://opaquenamespace.org/ns/hydra/owner'), multiple: false

--- a/app/presenters/curation_concerns/composite_presenter_factory.rb
+++ b/app/presenters/curation_concerns/composite_presenter_factory.rb
@@ -1,0 +1,22 @@
+module CurationConcerns
+  ##
+  # Dynamic presenter which instantiates a file set presenter if given an object
+  #   with a given ID, but otherwise instantiates a work presenter.
+  class CompositePresenterFactory
+    attr_reader :file_set_presenter_class, :work_presenter_class, :file_set_ids
+    def initialize(file_set_presenter_class, work_presenter_class, file_set_ids)
+      @file_set_presenter_class = file_set_presenter_class
+      @work_presenter_class = work_presenter_class
+      @file_set_ids = file_set_ids
+    end
+
+    def new(*args)
+      obj = args.first
+      if file_set_ids.include?(obj.id)
+        file_set_presenter_class.new(*args)
+      else
+        work_presenter_class.new(*args)
+      end
+    end
+  end
+end

--- a/app/presenters/curation_concerns/model_proxy.rb
+++ b/app/presenters/curation_concerns/model_proxy.rb
@@ -4,7 +4,7 @@ module CurationConcerns
   module ModelProxy
     delegate :to_param, :to_key, :id, to: :solr_document
 
-    delegate :model_name, to: :_delegated_to
+    delegate :model_name, :valid_child_concerns, to: :_delegated_to
 
     def to_partial_path
       _delegated_to._to_partial_path

--- a/app/services/curation_concerns/actors/actor_factory.rb
+++ b/app/services/curation_concerns/actors/actor_factory.rb
@@ -9,6 +9,7 @@ module CurationConcerns
 
       def self.stack_actors(curation_concern)
         [AddToCollectionActor,
+         AddToWorkActor,
          AssignRepresentativeActor,
          AttachFilesActor,
          ApplyOrderActor,

--- a/app/services/curation_concerns/contextual_path.rb
+++ b/app/services/curation_concerns/contextual_path.rb
@@ -1,0 +1,19 @@
+module CurationConcerns
+  class ContextualPath
+    include Rails.application.routes.url_helpers
+    include ActionDispatch::Routing::PolymorphicRoutes
+    attr_reader :presenter, :parent_presenter
+    def initialize(presenter, parent_presenter)
+      @presenter = presenter
+      @parent_presenter = parent_presenter
+    end
+
+    def show
+      if parent_presenter
+        polymorphic_path([:curation_concerns, :parent, presenter.model_name.singular], parent_id: parent_presenter.id, id: presenter.id)
+      else
+        polymorphic_path([presenter])
+      end
+    end
+  end
+end

--- a/app/services/curation_concerns/thumbnail_path_service.rb
+++ b/app/services/curation_concerns/thumbnail_path_service.rb
@@ -8,6 +8,7 @@ module CurationConcerns
 
         thumb = fetch_thumbnail(object)
         return unless thumb
+        return call(thumb) unless thumb.is_a?(::FileSet)
         if thumb.audio?
           audio_image
         elsif thumbnail?(thumb)
@@ -19,7 +20,7 @@ module CurationConcerns
 
       def fetch_thumbnail(object)
         return object if object.thumbnail_id == object.id
-        ::FileSet.find(object.thumbnail_id)
+        ::ActiveFedora::Base.find(object.thumbnail_id)
       rescue ActiveFedora::ObjectNotFoundError
         Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
         nil

--- a/app/views/curation_concerns/base/_actions.html.erb
+++ b/app/views/curation_concerns/base/_actions.html.erb
@@ -1,0 +1,3 @@
+<% if member.model_name.singular.to_sym == :file_set %>
+  <%= render "curation_concerns/file_sets/actions", file_set: member %>
+<% end %>

--- a/app/views/curation_concerns/base/_file_manager_member.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_member.html.erb
@@ -6,7 +6,7 @@
           <%= f.input :title, as: :string, input_html: { name: "#{f.object.model_name.singular}[title][]", class: "title" }, value: node.to_s, label: false %>
         </div>
         <div class="file-set-link pull-right">
-          <%= link_to polymorphic_path([main_app, node]), title: "Edit file" do %>
+          <%= link_to contextual_path(node, @presenter), title: "Edit file" do %>
             <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
           <% end %>
         </div>

--- a/app/views/curation_concerns/base/_file_manager_members.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_members.html.erb
@@ -1,5 +1,5 @@
 <ul id="sortable" data-id="<%= @presenter.id %>" data-class-name="<%= @presenter.model_name.plural %>" data-singular-class-name="<%= @presenter.model_name.singular %>" class="list-unstyled grid clearfix">
- <% @presenter.file_presenters.each do |member| %>
+ <% @presenter.member_presenters.each do |member| %>
    <%= render "file_manager_member", node: member %>
  <% end %>
 </ul>

--- a/app/views/curation_concerns/base/_form_in_works.html.erb
+++ b/app/views/curation_concerns/base/_form_in_works.html.erb
@@ -1,0 +1,6 @@
+<% if params[:parent_id] %>
+  <% (f.object.in_works_ids + [params[:parent_id]]).uniq.each do |work_id| %>
+    <%= f.input :in_works_ids, as: :hidden, input_html: { value: work_id, multiple: true } %>
+  <% end %>
+  <%= hidden_field_tag 'parent_id', params[:parent_id] %>
+<% end %>

--- a/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/base/_form_supplementary_fields.html.erb
@@ -8,3 +8,4 @@
 </div>
 
 <%= render "form_rights", f: f %>
+<%= render "form_in_works", f: f %>

--- a/app/views/curation_concerns/base/_member.html.erb
+++ b/app/views/curation_concerns/base/_member.html.erb
@@ -2,11 +2,11 @@
   <td class="thumbnail">
     <%= render_thumbnail_tag member %>
   </td>
-  <td class="attribute filename"><%= link_to(member.link_name, main_app.curation_concerns_file_set_path(member)) %></td>
-  <td class="attribute date_uploaded"><%= member.date_uploaded %></td>
+  <td class="attribute filename"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+  <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>
   <td class="attribute permission"><%= member.permission_badge %></td>
   <td>
-    <%= render 'curation_concerns/file_sets/actions', file_set: member %>
+    <%= render 'actions', member: member %>
   </td>
 </tr>
 

--- a/app/views/curation_concerns/base/_related_files.html.erb
+++ b/app/views/curation_concerns/base/_related_files.html.erb
@@ -1,7 +1,7 @@
-<% if presenter.file_set_presenters.present? %>
+<% if presenter.member_presenters.present? %>
 <div class="panel panel-default related_files">
   <div class="panel-heading">
-    <h2>Files</h2>
+    <h2><%= t('curation_concerns.show.related_files.heading') %></h2>
   </div>
   <table class="table table-striped">
     <thead>
@@ -14,11 +14,11 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'member', collection: presenter.file_set_presenters %>
+      <%= render partial: 'member', collection: presenter.member_presenters %>
     </tbody>
   </table>
 </div>
 <% elsif can? :edit, presenter.id %>
-  <h2>Files</h2>
-  <p class="text-center"><em>This <%= presenter.human_readable_type %> has no files associated with it. You can add one using the "Attach a File" button below.</em></p>
+  <h2><%= t('curation_concerns.show.related_files.heading') %></h2>
+  <p class="text-center"><em>This <%= presenter.human_readable_type %> has no members associated with it. You can add one using the "Attach a File" button below.</em></p>
 <% end %>

--- a/app/views/curation_concerns/base/_representative_media.html.erb
+++ b/app/views/curation_concerns/base/_representative_media.html.erb
@@ -1,4 +1,4 @@
-<% if presenter.representative_id.present? %>
+<% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
   <%= media_display presenter.representative_presenter %>
 <% else %>
   <%= image_tag 'nope.png', class: "canonical-image" %>

--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -4,6 +4,20 @@
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
       <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
       <%= link_to t("file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-default' %>
+      <% if @presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Attach Child <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <% @presenter.valid_child_concerns.each do |concern| %>
+              <li>
+                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :curation_concerns, :parent, concern.model_name.singular], parent_id: @presenter.id) %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
       <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
     <% end %>
     <% if collector %>

--- a/app/views/curation_concerns/base/file_manager.html.erb
+++ b/app/views/curation_concerns/base/file_manager.html.erb
@@ -5,7 +5,7 @@
   </li>
 </ul>
 
-<% if !@presenter.file_presenters.empty? %>
+<% if !@presenter.member_presenters.empty? %>
   <div data-action="file-manager">
     <div class="col-md-3" id="file-manager-tools">
       <h2>Toolbar</h2>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -1,6 +1,14 @@
 <% provide :page_title, @presenter.page_title %>
 <% provide :page_header do %>
-  <h1><%= @presenter %> <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span></h1>
+  <h1><%= @presenter %> </h1>
+  <% if @parent_presenter %>
+    <ul class="breadcrumb">
+      <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>
+      <li class="active"><%= @presenter.human_readable_type %></li>
+    </ul>
+  <% else %>
+    <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span>
+  <% end %>
 <% end %>
 
 <% collector = can?(:collect, @presenter.id) %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -14,6 +14,9 @@ en:
     institution:
       name: "Your Institution"
       homepage_url: "#"
+    show:
+      related_files:
+        heading: 'Members'
     search:
       form:
         q:

--- a/lib/curation_concerns/rails/routes.rb
+++ b/lib/curation_concerns/rails/routes.rb
@@ -19,6 +19,16 @@ module ActionDispatch::Routing
           end
         end
 
+        resources :parent, only: [] do
+          concerns_to_route.each do |curation_concern_name|
+            namespaced_resources curation_concern_name, except: [:index], &block
+          end
+        end
+
+        resources :parent, only: [] do
+          resources :file_sets, only: [:show]
+        end
+
         resources :permissions, only: [] do
           member do
             get :confirm

--- a/lib/generators/curation_concerns/work/templates/model.rb.erb
+++ b/lib/generators/curation_concerns/work/templates/model.rb.erb
@@ -3,5 +3,7 @@
 class <%= class_name %> < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
+  # Change this to restrict which works can be added as a child.
+  # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -13,6 +13,15 @@ describe CurationConcerns::GenericWorksController do
         get :show, id: a_work
         expect(response).to be_success
       end
+      context "with a parent work" do
+        render_views
+        it "renders a breadcrumb" do
+          parent = create(:generic_work, title: ['Parent Work'], user: user, ordered_members: [a_work])
+          get :show, id: a_work, parent_id: parent
+
+          expect(response.body).to have_content "Parent Work"
+        end
+      end
     end
 
     context 'someone elses private work' do

--- a/spec/features/create_child_work_spec.rb
+++ b/spec/features/create_child_work_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'redlock'
+
+feature 'Creating a new child Work' do
+  let(:user) { FactoryGirl.create(:user) }
+
+  let(:redlock_client_stub) { # stub out redis connection
+    client = double('redlock client')
+    allow(client).to receive(:lock).and_yield(true)
+    allow(Redlock::Client).to receive(:new).and_return(client)
+    client
+  }
+  let(:parent) { FactoryGirl.create(:generic_work, user: user, title: ["Parent First"]) }
+
+  before do
+    sign_in user
+
+    # stub out characterization. Travis doesn't have fits installed, and it's not relevant to the test.
+    allow(CharacterizeJob).to receive(:perform_later)
+    redlock_client_stub
+    parent
+  end
+
+  it 'creates the child work' do
+    visit "/concern/parent/#{parent.id}/generic_works/new"
+    work_title = 'My Test Work'
+    within('form.new_generic_work') do
+      fill_in('Title', with: work_title)
+      click_on('Create Generic work')
+    end
+    expect(page).to have_content parent.title.first
+    visit "/concern/generic_works/#{parent.id}"
+    expect(page).to have_content work_title
+  end
+
+  context "when it's being updated" do
+    let(:curation_concern) { FactoryGirl.create(:generic_work, user: user) }
+    before do
+      parent.ordered_members << curation_concern
+      parent.save!
+    end
+    it 'can be updated' do
+      visit "/concern/parent/#{parent.id}/generic_works/#{curation_concern.id}/edit"
+      click_on "Update Generic work"
+
+      expect(parent.reload.ordered_members.to_a.length).to eq 1
+    end
+    it "doesn't lose other memberships" do
+      new_parent = FactoryGirl.create(:generic_work, user: user)
+      new_parent.ordered_members << curation_concern
+      new_parent.save!
+
+      visit "/concern/parent/#{parent.id}/generic_works/#{curation_concern.id}/edit"
+      click_on "Update Generic work"
+
+      expect(parent.reload.ordered_members.to_a.length).to eq 1
+      expect(new_parent.reload.ordered_members.to_a.length).to eq 1
+
+      expect(curation_concern.reload.in_works_ids.length).to eq 2
+    end
+  end
+end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -14,6 +14,11 @@ describe GenericWork do
     it { is_expected.to eq 'curation_concerns_generic_work' }
   end
 
+  describe '.valid_child_concerns' do
+    it "is all registered curation concerns by default" do
+      expect(described_class.valid_child_concerns).to eq [described_class]
+    end
+  end
   context 'with attached files' do
     subject { FactoryGirl.create(:work_with_files) }
 
@@ -26,6 +31,13 @@ describe GenericWork do
   describe '#indexer' do
     subject { described_class.indexer }
     it { is_expected.to eq CurationConcerns::WorkIndexer }
+  end
+  context "with children" do
+    subject { FactoryGirl.create(:work_with_file_and_work) }
+    it "can have the thumbnail set to the work" do
+      subject.thumbnail = subject.ordered_members.to_a.last
+      expect(subject.save).to eq true
+    end
   end
 
   describe 'to_solr' do
@@ -61,5 +73,18 @@ describe GenericWork do
     let(:work) { described_class.new(id: '123') }
     subject { work.to_global_id }
     it { is_expected.to be_kind_of GlobalID }
+  end
+
+  describe "#in_works_ids" do
+    let(:parent) { FactoryGirl.create(:generic_work) }
+    subject { FactoryGirl.create(:generic_work) }
+    before do
+      parent.ordered_members << subject
+      parent.save!
+    end
+
+    it "returns ids" do
+      expect(subject.in_works_ids).to eq [parent.id]
+    end
   end
 end

--- a/spec/presenters/curation_concerns/work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/work_show_presenter_spec.rb
@@ -61,6 +61,17 @@ describe CurationConcerns::WorkShowPresenter do
     end
   end
 
+  describe "#member_presenters" do
+    let(:obj) { create(:work_with_file_and_work) }
+    let(:attributes) { obj.to_solr }
+
+    it "returns appropriate classes for each" do
+      expect(presenter.member_presenters.size).to eq 2
+      expect(presenter.member_presenters.first).to be_instance_of(::CurationConcerns::FileSetPresenter)
+      expect(presenter.member_presenters.last).to be_instance_of(described_class)
+    end
+  end
+
   describe "#file_set_presenters" do
     let(:obj) { create(:work_with_ordered_files) }
     let(:attributes) { obj.to_solr }
@@ -86,7 +97,7 @@ describe CurationConcerns::WorkShowPresenter do
       let(:attributes) { {} }
       let(:presenter_class) { double }
       before do
-        allow(presenter).to receive(:file_presenter_class).and_return(presenter_class)
+        allow(presenter).to receive(:composite_presenter_class).and_return(presenter_class)
         allow(presenter).to receive(:ordered_ids).and_return(['12', '33'])
         allow(presenter).to receive(:file_set_ids).and_return(['33', '12'])
       end
@@ -104,7 +115,7 @@ describe CurationConcerns::WorkShowPresenter do
     let(:attributes) { obj.to_solr }
     let(:presenter_class) { double }
     before do
-      allow(presenter).to receive(:file_presenter_class).and_return(presenter_class)
+      allow(presenter).to receive(:composite_presenter_class).and_return(presenter_class)
     end
     it "has a representative" do
       expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
@@ -132,6 +143,15 @@ describe CurationConcerns::WorkShowPresenter do
   describe '#page_title' do
     subject { presenter.page_title }
     it { is_expected.to eq 'foo' }
+  end
+
+  describe "#valid_child_concerns" do
+    subject { presenter }
+    it "delegates to the class attribute of the model" do
+      allow(GenericWork).to receive(:valid_child_concerns).and_return([GenericWork])
+
+      expect(subject.valid_child_concerns).to eq [GenericWork]
+    end
   end
 
   describe "#attribute_to_html" do

--- a/spec/services/thumbnail_path_service_spec.rb
+++ b/spec/services/thumbnail_path_service_spec.rb
@@ -32,7 +32,7 @@ describe CurationConcerns::ThumbnailPathService do
       let(:original_file)  { mock_file_factory(mime_type: 'image/jpeg') }
       before do
         allow(File).to receive(:exist?).and_return(true)
-        allow(FileSet).to receive(:find).with('999').and_return(representative)
+        allow(ActiveFedora::Base).to receive(:find).with('999').and_return(representative)
         allow(representative).to receive(:original_file).and_return(original_file)
       end
 

--- a/spec/views/curation_concerns/base/_member.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_member.html.erb_spec.rb
@@ -25,6 +25,9 @@ describe 'curation_concerns/base/_member.html.erb' do
     allow(view).to receive(:can?).with(:read, kind_of(String)).and_return(true)
     allow(view).to receive(:can?).with(:edit, kind_of(String)).and_return(true)
     allow(view).to receive(:can?).with(:destroy, String).and_return(true)
+    allow(view).to receive(:contextual_path).with(anything, anything) do |x, y|
+      CurationConcerns::ContextualPath.new(x, y).show
+    end
     render 'curation_concerns/base/member.html.erb', member: presenter
   end
 

--- a/spec/views/curation_concerns/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_show_actions.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'curation_concerns/base/show_actions' do
   let(:model) { double('model', persisted?: true, to_param: '123', model_name: GenericWork.model_name) }
-  let(:presenter) { double("presenter", human_readable_type: 'Image', id: '123', to_model: model) }
+  let(:presenter) { double("presenter", human_readable_type: 'Image', id: '123', to_model: model, valid_child_concerns: [GenericWork]) }
   before do
     assign(:presenter, presenter)
     render 'curation_concerns/base/show_actions.html.erb', collector: collector, editor: editor
@@ -13,6 +13,15 @@ describe 'curation_concerns/base/show_actions' do
     let(:collector) { true }
     it "shows the add to collection link" do
       expect(rendered).to have_link 'Add to a Collection'
+    end
+  end
+  context "as an editor" do
+    let(:editor) { true }
+    let(:collector) { true }
+    context "when there are valid_child_concerns" do
+      it "creates a link" do
+        expect(rendered).to have_link 'Attach Generic Work', href: "/concern/parent/#{presenter.id}/generic_works/new"
+      end
     end
   end
 end

--- a/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe "curation_concerns/base/file_manager.html.erb" do
-  let(:members) { [file_set] }
+  let(:members) { [file_set, member] }
   let(:file_set) { CurationConcerns::FileSetPresenter.new(solr_doc, nil) }
+  let(:member) { CurationConcerns::WorkShowPresenter.new(solr_doc_work, nil) }
   let(:solr_doc) do
     SolrDocument.new(
       resource.to_solr.merge(
@@ -10,6 +11,16 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
         title_tesim: "Test",
         thumbnail_path_ss: "/test/image/path.jpg",
         label_tesim: ["file_name.tif"]
+      )
+    )
+  end
+  let(:solr_doc_work) do
+    SolrDocument.new(
+      resource.to_solr.merge(
+        id: "work",
+        title_tesim: "Work",
+        thumbnail_path_ss: "/test/image/path.jpg",
+        label_tesim: ["work"]
       )
     )
   end
@@ -26,7 +37,7 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
   let(:blacklight_config) { CatalogController.new.blacklight_config }
 
   before do
-    allow(parent_presenter).to receive(:file_presenters).and_return([file_set])
+    allow(parent_presenter).to receive(:member_presenters).and_return([file_set, member])
     assign(:presenter, parent_presenter)
     # Blacklight nonsense
     allow(view).to receive(:dom_class) { '' }
@@ -35,6 +46,9 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
     allow(view).to receive(:search_session).and_return({})
     allow(view).to receive(:current_search_session).and_return(nil)
     allow(view).to receive(:curation_concern).and_return(parent)
+    allow(view).to receive(:contextual_path).with(anything, anything) do |x, y|
+      CurationConcerns::ContextualPath.new(x, y).show
+    end
     render
   end
 


### PR DESCRIPTION
Adds nested works, but I have some questions about how far to go:

Features in PR
============

1. "Attach Child Generic Work" button created.
2. Configurable settings for which items can be children.
3. File Manager can reorder/set labels for both FileSets and Works.
4. "Files" display is now "Members" display.

Potential Features (AKA should I try to add these?)
==============

1. Breadcrumb Paths (Does this mean a recursive show path for a work with works with works?)
2. Thumbnail Selection (Allow a child Generic Work to be representative - so its thumbnail is the parent's thumbnail)
3. Default Discovery (Should children be discoverable? Or just leave this up to implementors?)
4. Indexing of parents (Necessary for filtering discovery, but may be an upstream concern?)