### PR TITLE
Fix issue with rights and source attributes

### DIFF
--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -15,7 +15,7 @@ module CurationConcerns
                     :representative_id, :thumbnail_id, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
-                    :visibility, :ordered_member_ids]
+                    :visibility, :ordered_member_ids, :source]
 
       self.required_fields = [:title]
 
@@ -40,17 +40,10 @@ module CurationConcerns
 
       class << self
         # This determines whether the allowed parameters are single or multiple.
-        # By default it delegates to the model, but we need to override for
-        # 'rights' which only has a single value on the form.
+        # By default it delegates to the model.
         def multiple?(term)
-          case term.to_s
-          when 'rights'
-            false
-          when 'ordered_member_ids'
-            true
-          else
-            super
-          end
+          return true if term.to_s == 'ordered_member_ids'
+          super
         end
 
         # Overriden to cast 'rights' to an array

--- a/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -112,7 +112,7 @@ module CurationConcerns
     end
 
     def rights
-      self[Solrizer.solr_name('rights')]
+      fetch(Solrizer.solr_name('rights'), [])
     end
 
     def mime_type
@@ -121,6 +121,10 @@ module CurationConcerns
 
     def read_groups
       fetch(Hydra.config.permissions.read.group, [])
+    end
+
+    def source
+      fetch(Solrizer.solr_name('source'), [])
     end
 
     def visibility

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -35,7 +35,7 @@ module CurationConcerns
     # Metadata Methods
     delegate :title, :date_created, :date_modified, :date_uploaded, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
-             :lease_expiration_date, :rights, to: :solr_document
+             :lease_expiration_date, :rights, :source, to: :solr_document
 
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_set_presenters

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -4,4 +4,4 @@
   <%= presenter.attribute_to_html(:subject, render_as: :linked) %>
   <%= presenter.attribute_to_html(:publisher) %>
   <%= presenter.attribute_to_html(:language) %>
-
+  <%= presenter.attribute_to_html(:source) %>

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -22,12 +22,20 @@ feature 'Creating a new Work' do
   it 'creates the work and allow you to attach a file' do
     visit '/concern/generic_works/new'
     work_title = 'My Test Work'
+    source = 'related resource'
     within('form.new_generic_work') do
       fill_in('Title', with: work_title)
+      fill_in('Source', with: source)
+      select 'Attribution 3.0 United States', from: 'generic_work[rights][]'
       attach_file('Upload a file', fixture_file_path('files/image.png'))
       choose('generic_work_visibility_open')
       click_on('Create Generic work')
     end
+
+    expect(page).to have_content(source)
+    expect(page).to have_link 'Attribution 3.0 United States',
+                              href: 'http://creativecommons.org/licenses/by/3.0/us/'
+
     within '.related_files' do
       expect(page).to have_link 'image.png'
     end

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -46,7 +46,8 @@ describe CurationConcerns::Forms::WorkForm do
       representative_id: '456',
       thumbnail_id: '789',
       keyword: ['derp'],
-      rights: 'http://creativecommons.org/licenses/by/3.0/us/')
+      source: ['related'],
+      rights: ['http://creativecommons.org/licenses/by/3.0/us/'])
     }
     subject { PirateShipForm.model_attributes(params) }
 
@@ -56,6 +57,7 @@ describe CurationConcerns::Forms::WorkForm do
       expect(subject['visibility']).to eq 'open'
       expect(subject['rights']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
       expect(subject['keyword']).to eq ['derp']
+      expect(subject['source']).to eq ['related']
     end
 
     it 'excludes non-permitted params' do


### PR DESCRIPTION
Fixes #831 

Corrects issue with unpermitted source and rights parameters.

The rights field became multi-valued in #817, but the overridden `multiple?` method in `forms/work_form` forced the param to be single-valued. The source field was not included in the terms array, solr document, or in the attribute_rows view partial. It was added and now both attributes can be saved and viewed on the show page.

@projecthydra/sufia-code-reviewers
