### PR TITLE
Raise an error if no file_set_ids or member_ids were passed

### DIFF
--- a/app/presenters/curation_concerns/composite_presenter_factory.rb
+++ b/app/presenters/curation_concerns/composite_presenter_factory.rb
@@ -12,6 +12,7 @@ module CurationConcerns
 
     def new(*args)
       obj = args.first
+      raise ArgumentError, "You must provide some ids" unless file_set_ids.present?
       if file_set_ids.include?(obj.id)
         file_set_presenter_class.new(*args)
       else


### PR DESCRIPTION
If we don't trap for this error state an infinite loop can arise.