### PR TITLE
Mark the title field as required for the collection edit form

### DIFF
--- a/app/forms/curation_concerns/forms/collection_edit_form.rb
+++ b/app/forms/curation_concerns/forms/collection_edit_form.rb
@@ -11,6 +11,8 @@ module CurationConcerns
                     :representative_id, :thumbnail_id, :identifier, :based_near,
                     :related_url, :visibility]
 
+      self.required_fields = [:title]
+
       # Test to see if the given field is required
       # @param [Symbol] key a field
       # @return [Boolean] is it required or not

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -17,6 +17,17 @@ feature 'collection' do
     Collection.destroy_all
   end
 
+  describe 'collection creation fields' do
+    before do
+      sign_in user
+      visit '/collections/new'
+    end
+
+    it 'visibly marks the title field as required' do
+      expect(page).to have_content 'Title required'
+    end
+  end
+
   describe 'create collection' do
     before do
       sign_in user


### PR DESCRIPTION
Fixes projecthydra/sufia#2106

The title field isn't being marked as required for collections in CC/Sufia.

Ongoing work: I am going to look into automatically getting this data from the model.

@projecthydra/sufia-code-reviewers
