### PR TITLE
[ci skip] Update the release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,4 @@
+* Checkout the master branch.
 * Bump version number in `lib/curation_concerns/version.rb`
-* Commit and push your change to the master branch
-* Release the gem to rubygems.org: `rake build` then `rake release`
+* Commit your change with a message such as: `Bumped version to x.y.z`
+* Release the gem to rubygems.org: `rake release` This also pushes the code to github.


### PR DESCRIPTION
This way has fewer steps and is more explicit about the expected commit message.