### PR TITLE
SearchBuilders no longer need ability set

### DIFF
--- a/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
@@ -160,9 +160,7 @@ module CurationConcerns
       end
 
       def collection_search_builder
-        collection_search_builder_class.new(self).with(params.except(:q, :page)).tap do |builder|
-          builder.current_ability = current_ability
-        end
+        collection_search_builder_class.new(self).with(params.except(:q, :page))
       end
 
       def collection_search_builder_class
@@ -203,9 +201,7 @@ module CurationConcerns
       end
 
       def collection_member_search_builder
-        @collection_member_search_builder ||= collection_member_search_builder_class.new(self).tap do |builder|
-          builder.current_ability = current_ability
-        end
+        @collection_member_search_builder ||= collection_member_search_builder_class.new(self)
       end
 
       def process_member_changes

--- a/app/controllers/concerns/curation_concerns/selects_collections.rb
+++ b/app/controllers/concerns/curation_concerns/selects_collections.rb
@@ -58,7 +58,6 @@ module CurationConcerns::SelectsCollections
 
   def collections_search_builder(access_level = nil)
     collections_search_builder_class.new(self).tap do |builder|
-      builder.current_ability = current_ability
       builder.discovery_perms = access_levels[access_level] if access_level
     end
   end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

As of blacklight-acccess-controls 0.4.0