### PR TITLE
Use thumbnail_url blacklight helper

### DIFF
--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -1,7 +1,7 @@
 <% if CurationConcerns.config.display_media_download_link %>
     <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized image" do %>
         <figure>
-            <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
+            <%= image_tag thumbnail_url(file_set),
                           class: "img-responsive",
                           alt: "Download the full-sized image of #{file_set.to_s}" %>
             <figcaption>Download the full-sized image</figcaption>
@@ -9,7 +9,7 @@
     <% end %>
 <% else %>
     <figure>
-        <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
+        <%= image_tag thumbnail_url(file_set),
                       class: "img-responsive",
                       alt: "Thumbnail of #{file_set.to_s}" %>
     </figure>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -1,7 +1,7 @@
 <% if CurationConcerns.config.display_media_download_link %>
     <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
         <figure>
-            <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
+            <%= image_tag thumbnail_url(file_set),
                           class: "img-responsive",
                           alt: "Download the document #{file_set.to_s}" %>
             <figcaption>Download the document</figcaption>
@@ -9,7 +9,7 @@
     <% end %>
 <% else %>
     <figure>
-        <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
+        <%= image_tag thumbnail_url(file_set),
                       class: "img-responsive",
                       alt: "Thumbnail of #{file_set.to_s}" %>
     </figure>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,7 +1,7 @@
 <% if CurationConcerns.config.display_media_download_link %>
     <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized PDF" do %>
         <figure>
-            <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
+            <%= image_tag thumbnail_url(file_set),
                           class: "img-responsive",
                           alt: "Download the full-sized PDF of #{file_set.to_s}" %>
             <figcaption>Download the full-sized PDF</figcaption>
@@ -9,7 +9,7 @@
     <% end %>
 <% else %>
     <figure>
-        <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
+        <%= image_tag thumbnail_url(file_set),
                       class: "img-responsive",
                       alt: "Thumbnail of #{file_set.to_s}" %>
     </figure>

--- a/spec/views/curation_concerns/file_sets/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/show.html.erb_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe 'curation_concerns/file_sets/show.html.erb', type: :view do
   before do
     allow(view).to receive(:parent).and_return(parent)
+    allow(view).to receive_messages(blacklight_config: CatalogController.blacklight_config,
+                                    blacklight_configuration_context: Blacklight::Configuration::Context.new(controller))
   end
 
   let(:parent) { stub_model(GenericWork) }


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Rather than coding a path to the download controller.
This allows us to swap in a different thumbnail path service and use
that value throughout the site. This enables swapping in a IIIF
thumbnail path service.