### PR TITLE
Don't override #required? in CollectionEditForm

### DIFF
--- a/app/forms/curation_concerns/forms/collection_edit_form.rb
+++ b/app/forms/curation_concerns/forms/collection_edit_form.rb
@@ -13,13 +13,6 @@ module CurationConcerns
 
       self.required_fields = [:title]
 
-      # Test to see if the given field is required
-      # @param [Symbol] key a field
-      # @return [Boolean] is it required or not
-      def required?(key)
-        model_class.validators_on(key).any? { |v| v.is_a? ActiveModel::Validations::PresenceValidator }
-      end
-
       # @return [Hash] All FileSets in the collection, file.to_s is the key, file.id is the value
       def select_files
         Hash[all_files]

--- a/spec/forms/collection_edit_form_spec.rb
+++ b/spec/forms/collection_edit_form_spec.rb
@@ -13,6 +13,11 @@ describe CurationConcerns::Forms::CollectionEditForm do
     end
   end
 
+  describe "#required?" do
+    subject { form.required?(:title) }
+    it { is_expected.to be true }
+  end
+
   describe "#human_readable_type" do
     subject { form.human_readable_type }
     it { is_expected.to eq 'Collection' }


### PR DESCRIPTION
The override wasn't doing anything and didn't mesh with how it was being called in places like `views/records/edit_fields/_default.html.erb`