### PR TITLE
Update Collection when a member work is deleted

### DIFF
--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -93,8 +93,17 @@ module CurationConcerns::CurationConcernController
     end
   end
 
+  def remove_from_collection
+    curation_concern.in_collection_ids.each do |id|
+      destination_collection = ::Collection.find(id)
+      destination_collection.members.delete(curation_concern)
+      destination_collection.update_index
+    end
+  end
+
   def destroy
     title = curation_concern.to_s
+    remove_from_collection
     curation_concern.destroy
     CurationConcerns.config.callback.run(:after_destroy, curation_concern.id, current_user)
     after_destroy_response(title)


### PR DESCRIPTION
Fixes #853 

Present tense short summary (50 characters or less)
When a work is deleted, check if the work id is a member id of a collection. If found, delete the member id and update the collection

Changes proposed in this pull request:
* Add a method "remove_from_collection" in curation_concern_controller
* 
* 

@projecthydra/sufia-code-reviewers

