### PR TITLE
Add DestroyActor to remove work from collection and destroy the work

### DIFF
--- a/app/actors/curation_concerns/actors/actor_stack.rb
+++ b/app/actors/curation_concerns/actors/actor_stack.rb
@@ -24,6 +24,15 @@ module CurationConcerns
       def update(attributes)
         actor.update(attributes.with_indifferent_access)
       end
+
+      def destroy
+        curation_concern.in_collection_ids.each do |id|
+          destination_collection = ::Collection.find(id)
+          destination_collection.members.delete(curation_concern)
+          destination_collection.update_index
+        end
+        curation_concern.destroy
+      end
     end
   end
 end

--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -95,9 +95,10 @@ module CurationConcerns::CurationConcernController
 
   def destroy
     title = curation_concern.to_s
-    curation_concern.destroy
-    CurationConcerns.config.callback.run(:after_destroy, curation_concern.id, current_user)
-    after_destroy_response(title)
+    if actor.destroy
+      CurationConcerns.config.callback.run(:after_destroy, curation_concern.id, current_user)
+      after_destroy_response(title)
+    end
   end
 
   def file_manager


### PR DESCRIPTION


Fixes #853

Present tense short summary (50 characters or less)
When a work is deleted, check if the work id is a member id of a collection. If found, delete the member id and update the collection

Changes proposed in this pull request:
*  Add an actor to destroy the work
* check if the work is member of a collection, remove it and update the collection
* 

@projecthydra/sufia-code-reviewers

