### PR TITLE
Adds a method which allows for the assignment of children to parents.

### DIFF
--- a/app/actors/curation_concerns/actors/apply_order_actor.rb
+++ b/app/actors/curation_concerns/actors/apply_order_actor.rb
@@ -3,10 +3,26 @@ module CurationConcerns
     class ApplyOrderActor < AbstractActor
       def update(attributes)
         ordered_member_ids = attributes.delete(:ordered_member_ids)
+        sync_members(ordered_member_ids)
         apply_order(ordered_member_ids) && next_actor.update(attributes)
       end
 
       private
+
+        def sync_members(ordered_member_ids)
+          return true if ordered_member_ids.nil?
+          existing_members_ids = curation_concern.member_ids
+          (existing_members_ids - ordered_member_ids).each do |old_id|
+            work = ::ActiveFedora::Base.find(old_id)
+            curation_concern.ordered_members.delete(work)
+          end
+
+          (ordered_member_ids - existing_members_ids).each do |work_id|
+            work = ::ActiveFedora::Base.find(work_id)
+            curation_concern.ordered_members << work
+          end
+          true
+        end
 
         def apply_order(new_order)
           return true unless new_order

--- a/spec/actors/curation_concerns/apply_order_actor_spec.rb
+++ b/spec/actors/curation_concerns/apply_order_actor_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe CurationConcerns::Actors::ApplyOrderActor do
+  describe '#update' do
+    let(:curation_concern) { create(:work_with_two_children, user: user) }
+
+    let(:user) { create(:admin) }
+
+    subject do
+      CurationConcerns::Actors::ActorStack.new(curation_concern,
+                                               user,
+                                               [described_class,
+                                                CurationConcerns::Actors::GenericWorkActor])
+    end
+
+    context 'with ordered_member_ids that are already associated with the parent' do
+      let(:attributes) { { ordered_member_ids: ["Blah"] } }
+      let(:root_actor) { double }
+      before do
+        allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(root_actor)
+        allow(root_actor).to receive(:update).with({}).and_return(true)
+        curation_concern.apply_depositor_metadata(user.user_key)
+        curation_concern.save!
+      end
+      it "attaches the parent" do
+        expect(subject.update(attributes)).to be true
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:user) { create(:admin) }
+    let(:curation_concern) { create(:work_with_one_child, user: user) }
+    let(:child) { GenericWork.new("Blah3") }
+
+    subject do
+      CurationConcerns::Actors::ActorStack.new(curation_concern,
+                                               user,
+                                               [described_class,
+                                                CurationConcerns::Actors::GenericWorkActor])
+    end
+
+    context 'with ordered_members_ids that arent associated with the curation concern yet.' do
+      let(:attributes) { { ordered_member_ids: ["Blah3"] } }
+      let(:root_actor) { double }
+      before do
+        allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(root_actor)
+        allow(root_actor).to receive(:update).with({}).and_return(true)
+        child.title = ["Generic Title"]
+        child.apply_depositor_metadata(user.user_key)
+        child.save!
+        curation_concern.apply_depositor_metadata(user.user_key)
+        curation_concern.save!
+      end
+      it "attaches the parent" do
+        expect(subject.update(attributes)).to be true
+      end
+    end
+  end
+end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -23,6 +23,19 @@ FactoryGirl.define do
       end
     end
 
+    factory :work_with_one_child do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['A Contained Work'])
+      end
+    end
+
+    factory :work_with_two_children do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['A Contained Work'], id: "Blah")
+        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['Another Contained Work'], id: "Blah2")
+      end
+    end
+
     factory :work_with_representative_file do
       before(:create) do |work, evaluator|
         work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'])


### PR DESCRIPTION
Fixes #857 

This update achieves the ability to add new children to a parent work. We added a new method in the same module where it orders the children in the context of a parent work. This method breaks any relations the parent has to children and rebuilds those relationships based on the ordered_member_ids that are passed through the form.