### PR TITLE
Organize badges, add Slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # CurationConcerns
 
-[![Version](https://badge.fury.io/rb/curation_concerns.png)](http://badge.fury.io/rb/curation_concerns)
+Code: [![Version](https://badge.fury.io/rb/curation_concerns.png)](http://badge.fury.io/rb/curation_concerns)
 [![Build Status](https://travis-ci.org/projecthydra/curation_concerns.svg?branch=master)](https://travis-ci.org/projecthydra/curation_concerns)
 [![Coverage Status](https://coveralls.io/repos/projecthydra/curation_concerns/badge.svg?branch=master)](https://coveralls.io/r/projecthydra/curation_concerns?branch=master)
 [![Code Climate](https://codeclimate.com/github/projecthydra/curation_concerns/badges/gpa.svg)](https://codeclimate.com/github/projecthydra/curation_concerns)
-[![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE.txt)
+
+Docs: [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE.txt)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![API Docs](http://img.shields.io/badge/API-docs-blue.svg)](http://rubydoc.info/gems/curation_concerns)
+
+Join in: [![Slack Status](http://slack.projecthydra.org/badge.svg)](http://slack.projecthydra.org/) [![Ready](https://badge.waffle.io/projecthydra/curation_concerns.svg?label=ready&title=Ready)](http://waffle.io/projecthydra/curation_concerns)
+
 
 A Hydra-based Rails Engine that extends an application, adding the ability to Create, Read, Update and Destroy (CRUD) objects (based on [Hydra::Works](http://github.com/projecthydra/hydra-works)) and providing a generator for defining object types with custom workflows, views, access controls, etc.
 
@@ -108,4 +112,3 @@ rake curation_concerns:spec
 ## Help
 
 If you have questions or need help, please email the [Hydra community tech list](mailto:hydra-tech@googlegroups.com) or stop by the [Hydra community IRC channel](irc://irc.freenode.net/projecthydra).
-


### PR DESCRIPTION
Adds [Slack badge to the README](https://github.com/projecthydra/curation_concerns/blob/add_slack_badge/README.md) and slots the badges using the same groupings as [Sufia](https://github.com/projecthydra/sufia/blob/master/README.md).

@projecthydra/sufia-code-reviewers

