### PR TITLE
Reload derivatives to index extracted text

### DIFF
--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -8,7 +8,9 @@ class CreateDerivativesJob < ActiveJob::Base
     filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
 
     file_set.create_derivatives(filename)
-    # The thumbnail is indexed in the solr document, so reindex
+
+    # Reload from Fedora and reindex for thumbnail and extracted text
+    file_set.reload
     file_set.update_index
     file_set.parent.update_index if parent_needs_reindex?(file_set)
   end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,61 +1,95 @@
 require 'spec_helper'
 
 describe CreateDerivativesJob do
-  let(:id) { '123' }
-
   before do
     @ffmpeg_enabled = CurationConcerns.config.enable_ffmpeg
     CurationConcerns.config.enable_ffmpeg = true
-    allow(FileSet).to receive(:find).with(id).and_return(file_set)
-    allow(file_set).to receive(:mime_type).and_return('audio/x-wav')
-    allow(file_set).to receive(:id).and_return(id)
   end
 
-  let(:file) do
-    Hydra::PCDM::File.new.tap do |f|
-      f.content = 'foo'
-      f.original_name = 'picture.png'
-      f.save!
+  after { CurationConcerns.config.enable_ffmpeg = @ffmpeg_enabled }
+
+  context "with an audio file" do
+    let(:id)       { '123' }
+    let(:file_set) { FileSet.new }
+
+    let(:file) do
+      Hydra::PCDM::File.new.tap do |f|
+        f.content = 'foo'
+        f.original_name = 'picture.png'
+        f.save!
+      end
+    end
+
+    before do
+      allow(FileSet).to receive(:find).with(id).and_return(file_set)
+      allow(file_set).to receive(:id).and_return(id)
+      allow(file_set).to receive(:mime_type).and_return('audio/x-wav')
+    end
+
+    context "with a file name" do
+      it 'calls create_derivatives and save on a file set' do
+        expect(Hydra::Derivatives::AudioDerivatives).to receive(:create)
+        expect(file_set).to receive(:reload)
+        expect(file_set).to receive(:update_index)
+        described_class.perform_now(file_set, file.id)
+      end
+    end
+
+    context 'with a parent object' do
+      before do
+        allow(file_set).to receive(:parent).and_return(parent)
+        # Stub out the actual derivative creation
+        allow(file_set).to receive(:create_derivatives)
+      end
+
+      context 'when the file_set is the thumbnail of the parent' do
+        let(:parent) { GenericWork.new(thumbnail_id: id) }
+
+        it 'updates the index of the parent object' do
+          expect(file_set).to receive(:reload)
+          expect(parent).to receive(:update_index)
+          described_class.perform_now(file_set, file.id)
+        end
+      end
+
+      context "when the file_set isn't the parent's thumbnail" do
+        let(:parent) { GenericWork.new }
+
+        it "doesn't update the parent's index" do
+          expect(file_set).to receive(:reload)
+          expect(parent).to_not receive(:update_index)
+          described_class.perform_now(file_set, file.id)
+        end
+      end
     end
   end
 
-  let(:file_set) { FileSet.new }
+  context "with a pdf file" do
+    let(:file_set) { create(:file_set) }
+    let(:params)   { { qt: "search", q: "CutePDF", qf: "all_text_timv" } }
 
-  after do
-    CurationConcerns.config.enable_ffmpeg = @ffmpeg_enabled
-  end
+    let(:file) do
+      Hydra::PCDM::File.new.tap do |f|
+        f.content = File.open(File.join(fixture_path, "test.pdf")).read
+        f.original_name = 'test.pdf'
+        f.save!
+      end
+    end
 
-  context "with a file name" do
-    it 'calls create_derivatives and save on a file set' do
-      expect(Hydra::Derivatives::AudioDerivatives).to receive(:create)
-      expect(file_set).to receive(:update_index)
+    let(:search_response) do
+      Blacklight::Solr::Response.new(
+        Blacklight.default_index.connection.get("select", params: params),
+        params
+      )
+    end
+
+    before do
+      allow(file_set).to receive(:mime_type).and_return('application/pdf')
       described_class.perform_now(file_set, file.id)
     end
-  end
 
-  context 'with a parent object' do
-    before do
-      allow(file_set).to receive(:parent).and_return(parent)
-      # Stub out the actual derivative creation
-      expect(file_set).to receive(:create_derivatives)
-    end
-
-    context 'when the file_set is the thumbnail of the parent' do
-      let(:parent) { GenericWork.new(thumbnail_id: id) }
-
-      it 'updates the index of the parent object' do
-        expect(parent).to receive(:update_index)
-        described_class.perform_now(file_set, file.id)
-      end
-    end
-
-    context "when the file_set isn't the parent's thumbnail" do
-      let(:parent) { GenericWork.new }
-
-      it "doesn't update the parent's index" do
-        expect(parent).to_not receive(:update_index)
-        described_class.perform_now(file_set, file.id)
-      end
+    it "searches the extracted content" do
+      expect(search_response.documents.count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

When text is extracted from a file, it is not available on the file set
until the data is reloaded from Fedora. Reloading it makes it available
for indexing. Fixes projecthydra/sufia#1813.