### PR TITLE
Remove Google analytics, ref #827

### DIFF
--- a/app/views/layouts/boilerplate.html.erb
+++ b/app/views/layouts/boilerplate.html.erb
@@ -11,7 +11,6 @@
     <%= csrf_meta_tag %>
     <%= stylesheet_link_tag 'application' %>
     <%= javascript_include_tag 'application' %>
-    <%= render partial: 'shared/ga', formats: [:html] %>
   </head>
   <body>
 

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -9,8 +9,6 @@
 
     <!-- application js -->
     <%= javascript_include_tag 'application' %>
-
-    <%= render partial: 'shared/ga', formats: [:html] %>
   </head>
 
 <body>

--- a/app/views/shared/_ga.html.erb
+++ b/app/views/shared/_ga.html.erb
@@ -1,6 +1,0 @@
-<script>
-  var _gaq=[['_setAccount','<%= t('curation_concerns.google_analytics_id', default: 'TRACKME') %>'],['_trackPageview']];
-  (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-    g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g,s)}(document,'script'));
-</script>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -10,7 +10,6 @@ en:
       name: "Your Division at Institution"
       homepage_url: "#"
     document_language: "en"
-    google_analytics_id: ""
     institution:
       name: "Your Institution"
       homepage_url: "#"

--- a/lib/generators/curation_concerns/templates/config/curation_concerns.rb
+++ b/lib/generators/curation_concerns/templates/config/curation_concerns.rb
@@ -14,9 +14,6 @@ CurationConcerns.configure do |config|
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
   # config.analytics = false
 
-  # Specify a Google Analytics tracking ID to gather usage statistics
-  # config.google_analytics_id = 'UA-99999999-1'
-
   # Specify a date you wish to start collecting Google Analytic statistics for.
   # config.analytic_start_date = DateTime.new(2014,9,10)
 


### PR DESCRIPTION
Fixes #827 

Leave Google analytics up to the implementor, either Sufia or other.

@projecthydra/sufia-code-reviewers

