### PR TITLE
Avoid unnecessary calls to Fedora when downloading thumbnails

### DIFF
--- a/app/controllers/concerns/curation_concerns/download_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/download_behavior.rb
@@ -35,10 +35,11 @@ module CurationConcerns
         { type: mime_type_for(file), disposition: 'inline' }
       end
 
-      # Customize the :download ability in your Ability class, or override this method
+      # Customize the :read ability in your Ability class, or override this method.
+      # Hydra::Ability#download_permissions can't be used in this case because it assumes
+      # that files are in a LDP basic container, and thus, included in the asset's uri.
       def authorize_download!
-        # authorize! :download, file # can't use this because Hydra::Ability#download_permissions assumes that files are in Basic Container (and thus include the asset's uri)
-        authorize! :read, asset
+        authorize! :read, params[asset_param_key]
       end
 
       # Overrides Hydra::Controller::DownloadBehavior#load_file, which is hard-coded to assume files are in BasicContainer.
@@ -51,7 +52,7 @@ module CurationConcerns
         file_reference = params[:file]
         return default_file unless file_reference
 
-        file_path = CurationConcerns::DerivativePath.derivative_path_for_reference(asset, file_reference)
+        file_path = CurationConcerns::DerivativePath.derivative_path_for_reference(params[asset_param_key], file_reference)
         File.exist?(file_path) ? file_path : nil
       end
 

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -29,6 +29,11 @@ describe DownloadsController do
         expect(response).to redirect_to new_user_session_path
         expect(flash['alert']).to eq 'You are not authorized to access this page.'
       end
+
+      it 'authorizes the resource using only the id' do
+        expect(controller).to receive(:authorize!).with(:read, file_set.id)
+        get :show, id: file_set.to_param
+      end
     end
 
     context "when the user has access" do
@@ -56,6 +61,11 @@ describe DownloadsController do
             expect(response.body).to eq content
             expect(response.headers['Content-Length']).to eq "4218"
             expect(response.headers['Accept-Ranges']).to eq "bytes"
+          end
+
+          it 'retrieves the thumbnail without contacting Fedora' do
+            expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
+            get :show, id: file_set, file: 'thumbnail'
           end
         end
 


### PR DESCRIPTION
Removes calls to Fedora when loading pages like `/concerns/generic_works/1234` and enables them to load from Solr exclusively.

@projecthydra/sufia-code-reviewers