### PR TITLE
Update tests to work with QA 0.8.0

### DIFF
--- a/spec/services/rights_service_spec.rb
+++ b/spec/services/rights_service_spec.rb
@@ -4,7 +4,7 @@ describe RightsService do
   before do
     # Configure QA to use fixtures
     qa_fixtures = { local_path: File.expand_path('../../fixtures/authorities', __FILE__) }
-    stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
+    allow(Qa::Authorities::Local).to receive(:config).and_return(qa_fixtures)
   end
 
   describe "#select_active_options" do

--- a/spec/views/curation_concerns/base/_form_rights_spec.rb
+++ b/spec/views/curation_concerns/base/_form_rights_spec.rb
@@ -13,7 +13,7 @@ describe 'curation_concerns/base/_form_rights.html.erb' do
 
   before do
     qa_fixtures = { local_path: File.expand_path('../../../../fixtures/authorities', __FILE__) }
-    stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
+    allow(Qa::Authorities::Local).to receive(:config).and_return(qa_fixtures)
   end
 
   context "when active and inactive rights are associated with a work" do


### PR DESCRIPTION
The tests were stubbing a constant that no longer exists in QA.

@projecthydra/sufia-code-reviewers

