### PR TITLE
Allow a FileSet or an id for FileSetAuditService, fixes #874

### DIFF
--- a/spec/services/file_set_audit_service_spec.rb
+++ b/spec/services/file_set_audit_service_spec.rb
@@ -1,15 +1,16 @@
 require 'spec_helper'
 
 describe CurationConcerns::FileSetAuditService do
-  let(:f)       { create(:file_set, content: File.open(fixture_file_path('world.png'))) }
-  let(:service) { described_class.new(f) }
+  let(:f)                 { create(:file_set, content: File.open(fixture_file_path('world.png'))) }
+  let(:service_by_object) { described_class.new(f) }
+  let(:service_by_id)     { described_class.new(f.id) }
 
   describe '#audit' do
     context 'when a file has two versions' do
       before do
         CurationConcerns::VersioningService.create(f.original_file) # create a second version -- the factory creates the first version when it attaches +content+
       end
-      subject { service.audit[f.original_file.id] }
+      subject { service_by_object.audit[f.original_file.id] }
       specify 'returns two log results' do
         expect(subject.length).to eq(2)
       end
@@ -17,14 +18,14 @@ describe CurationConcerns::FileSetAuditService do
   end
 
   describe '#audit_file' do
-    subject { service.send(:audit_file, f.original_file) }
+    subject { service_by_object.send(:audit_file, f.original_file) }
     specify 'returns a single result' do
       expect(subject.length).to eq(1)
     end
   end
 
   describe '#audit_file_version' do
-    subject { service.send(:audit_file_version, f.original_file.id, f.original_file.uri) }
+    subject { service_by_object.send(:audit_file_version, f.original_file.id, f.original_file.uri) }
     specify 'returns a single ChecksumAuditLog for the given file' do
       expect(subject).to be_kind_of ChecksumAuditLog
       expect(subject.file_set_id).to eq(f.id)
@@ -33,7 +34,7 @@ describe CurationConcerns::FileSetAuditService do
   end
 
   describe '#audit_stat' do
-    subject { service.send(:audit_stat, f.original_file) }
+    subject { service_by_object.send(:audit_stat, f.original_file) }
     context 'when no audits have been run' do
       it 'reports that audits have not been run' do
         expect(subject).to eq 'Audits have not yet been run on this file.'
@@ -57,19 +58,44 @@ describe CurationConcerns::FileSetAuditService do
       CurationConcerns::VersioningService.create(f.original_file)
       ChecksumAuditLog.create!(pass: 1, file_set_id: f.id, version: f.original_file.versions.first.uri, file_id: 'original_file')
     end
-    subject { service.human_readable_audit_status }
+    subject { service_by_object.human_readable_audit_status }
     it { is_expected.to eq 'Some audits have not been run, but the ones run were passing.' }
   end
 
   describe '#logged_audit_status' do
-    subject { service.logged_audit_status }
+    context "with an object" do
+      subject { service_by_object.logged_audit_status }
 
-    it "doesn't trigger audits" do
-      expect(service).not_to receive(:audit_file)
-      expect(subject).to eq "Audits have not yet been run on this file."
+      it "doesn't trigger audits" do
+        expect(service_by_object).not_to receive(:audit_file)
+        expect(subject).to eq "Audits have not yet been run on this file."
+      end
+
+      context "when no audit is passing" do
+        before do
+          ChecksumAuditLog.create!(pass: 1, file_set_id: f.id, version: f.original_file.versions.first.label, file_id: 'original_file')
+        end
+
+        it "reports the audit result" do
+          expect(subject).to eq 'passing'
+        end
+      end
+
+      context "when one audit is passing" do
+        before do
+          ChecksumAuditLog.create!(pass: 0, file_set_id: f.id, version: f.original_file.versions.first.label, file_id: 'original_file')
+          ChecksumAuditLog.create!(pass: 1, file_set_id: f.id, version: f.original_file.versions.first.label, file_id: 'original_file')
+        end
+
+        it "reports the audit result" do
+          expect(subject).to eq 'failing'
+        end
+      end
     end
 
-    context "when no audit is passing" do
+    context "with an id" do
+      subject { service_by_id.logged_audit_status }
+
       before do
         ChecksumAuditLog.create!(pass: 1, file_set_id: f.id, version: f.original_file.versions.first.label, file_id: 'original_file')
       end
@@ -78,21 +104,10 @@ describe CurationConcerns::FileSetAuditService do
         expect(subject).to eq 'passing'
       end
     end
-
-    context "when one audit is passing" do
-      before do
-        ChecksumAuditLog.create!(pass: 0, file_set_id: f.id, version: f.original_file.versions.first.label, file_id: 'original_file')
-        ChecksumAuditLog.create!(pass: 1, file_set_id: f.id, version: f.original_file.versions.first.label, file_id: 'original_file')
-      end
-
-      it "reports the audit result" do
-        expect(subject).to eq 'failing'
-      end
-    end
   end
 
   describe '#stat_to_string' do
-    subject { service.send(:stat_to_string, val) }
+    subject { service_by_object.send(:stat_to_string, val) }
     context 'when audit_stat is 0' do
       let(:val) { 0 }
       it { is_expected.to eq 'failing' }


### PR DESCRIPTION
Fixes #874 

Allows `logged_audit_status` to be called without invoking Fedora. Required for https://github.com/projecthydra/sufia/issues/2326

@projecthydra/sufia-code-reviewers

