### PR TITLE
Allow https uris

### DIFF
--- a/app/services/curation_concerns/persist_directly_contained_output_file_service.rb
+++ b/app/services/curation_concerns/persist_directly_contained_output_file_service.rb
@@ -14,7 +14,7 @@ module CurationConcerns
       o_name = determine_original_name(file)
       m_type = determine_mime_type(file)
       uri = URI(directives.fetch(:url))
-      raise ArgumentError, "#{uri} is not an http uri" unless uri.scheme == 'http'
+      raise ArgumentError, "#{uri} is not an http(s) uri" unless uri.is_a?(URI::HTTP)
       file_set = ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri.to_s))
       remote_file = file_set.send("build_#{directives.fetch(:container)}".to_sym)
       remote_file.content = file


### PR DESCRIPTION
Fixes #877 

I've run the test suite locally against a SSL-enabled Fedora, however, I had to disable certificate verification because it was a self-signed cert. But, everything was going over ssl and there were no other failures. I also ran Sufia's test suite agains this branch of CurationConcerns, and it worked fine too.

So, I'd say this probably all we need to do to support SSL.

@projecthydra/sufia-code-reviewers

