### PR TITLE
Use ordered member ids instead of ids

### DIFF
--- a/app/actors/curation_concerns/actors/apply_order_actor.rb
+++ b/app/actors/curation_concerns/actors/apply_order_actor.rb
@@ -11,7 +11,7 @@ module CurationConcerns
 
         def sync_members(ordered_member_ids)
           return true if ordered_member_ids.nil?
-          existing_members_ids = curation_concern.member_ids
+          existing_members_ids = curation_concern.ordered_member_ids
           (existing_members_ids - ordered_member_ids).each do |old_id|
             work = ::ActiveFedora::Base.find(old_id)
             curation_concern.ordered_members.delete(work)


### PR DESCRIPTION
We had to change from using #member_ids to using #ordered_member_ids. member_ids was returning the full list of members including the one we were adding as a child in the attributes. This prevented the relationship from being persisted. 