### PR TITLE
Human-readable dates for Embargo and lease in Work Show View

### DIFF
--- a/app/renderers/curation_concerns/renderers/date_attribute_renderer.rb
+++ b/app/renderers/curation_concerns/renderers/date_attribute_renderer.rb
@@ -1,0 +1,11 @@
+module CurationConcerns
+  module Renderers
+    class DateAttributeRenderer < AttributeRenderer
+      private
+
+        def attribute_value_to_html(value)
+          Date.parse(value).to_formatted_s(:standard)
+        end
+    end
+  end
+end

--- a/app/views/curation_concerns/base/_attributes.html.erb
+++ b/app/views/curation_concerns/base/_attributes.html.erb
@@ -6,8 +6,8 @@
   <tbody>
     <%= render 'attribute_rows', presenter: presenter %>
     <%= presenter.attribute_to_html(:permission_badge, label: 'Visibility') %>
-    <%= presenter.attribute_to_html(:embargo_release_date) %>
-    <%= presenter.attribute_to_html(:lease_expiration_date) %>
+    <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date) %>
+    <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date) %>
     <%= presenter.attribute_to_html(:rights, render_as: :rights) %>
   </tbody>
 </table>

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -23,7 +23,7 @@ feature 'embargo' do
       click_button 'Create Generic work'
 
       # chosen embargo date is on the show page
-      expect(page).to have_content(future_date.to_datetime.iso8601.sub(/\+00:00/, 'Z'))
+      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
 
       click_link 'Edit This Generic Work'
       click_link 'Embargo Management Page'
@@ -34,7 +34,7 @@ feature 'embargo' do
       fill_in 'until', with: later_future_date.to_s
 
       click_button 'Update Embargo'
-      expect(page).to have_content(later_future_date.iso8601)
+      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard))
     end
   end
 

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -20,7 +20,7 @@ feature 'leases' do
       click_button 'Create Generic work'
 
       # chosen lease date is on the show page
-      expect(page).to have_content(future_date.to_datetime.iso8601.sub(/\+00:00/, 'Z'))
+      expect(page).to have_content(future_date.to_date.to_formatted_s(:standard))
 
       click_link 'Edit This Generic Work'
       click_link 'Lease Management Page'
@@ -31,7 +31,7 @@ feature 'leases' do
       fill_in 'until', with: later_future_date.to_s
 
       click_button 'Update Lease'
-      expect(page).to have_content(later_future_date.iso8601) # new lease date is displayed in message
+      expect(page).to have_content(later_future_date.to_date.to_formatted_s(:standard)) # new lease date is displayed in message
     end
   end
 

--- a/spec/renderers/curation_concerns/renderers/date_attribute_renderer_spec.rb
+++ b/spec/renderers/curation_concerns/renderers/date_attribute_renderer_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe CurationConcerns::Renderers::DateAttributeRenderer do
+  subject { Nokogiri::HTML(renderer.render) }
+  let(:expected) { Nokogiri::HTML(tr_content) }
+
+  describe "#attribute_to_html" do
+    context 'with embargo release date' do
+      let(:field) { :embargo_release_date }
+      let(:renderer) { described_class.new(field, ['2013-03-14T00:00:00Z']) }
+      let(:tr_content) {%(
+      <tr><th>Embargo release date</th>
+      <td><ul class="tabular">
+      <li class="attribute embargo_release_date">03/14/2013</li>
+      </ul></td></tr>
+      )}
+      it { expect(renderer).not_to be_microdata(field) }
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
+
+    context 'with lease expiration date' do
+      let(:field) { :lease_expiration_date }
+      let(:renderer) { described_class.new(field, ['2013-03-14T00:00:00Z']) }
+      let(:tr_content) {%(
+      <tr><th>Lease expiration date</th>
+      <td><ul class="tabular">
+      <li class="attribute lease_expiration_date">03/14/2013</li>
+      </ul></td></tr>
+      )}
+      it { expect(renderer).not_to be_microdata(field) }
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #881 

Changes proposed in this pull request:
* Adds new renderer to parse dates as :standard
* Attributes for embargo and lease display as human-readable date in show view for work and file set
* Updates existing tests and adds new renderer spec test

![screen shot 2016-07-20 at 2 11 24 pm](https://cloud.githubusercontent.com/assets/4163828/16997545/eed6cfb0-4e83-11e6-9bb3-d72f8f5c141b.png)

![screen shot 2016-07-20 at 2 12 45 pm](https://cloud.githubusercontent.com/assets/4163828/16997582/12bad962-4e84-11e6-8d9b-e165a10a0743.png)


@projecthydra/sufia-code-reviewers
