### PR TITLE
Add SingleUseLinkPresenter with internationalized settings

### DIFF
--- a/app/controllers/concerns/curation_concerns/single_use_links_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/single_use_links_controller_behavior.rb
@@ -2,6 +2,8 @@ module CurationConcerns
   module SingleUseLinksControllerBehavior
     extend ActiveSupport::Concern
     included do
+      class_attribute :show_presenter
+      self.show_presenter = CurationConcerns::SingleUseLinkPresenter
       before_action :authenticate_user!
       before_action :authorize_user!
       # Catch permission errors
@@ -26,7 +28,7 @@ module CurationConcerns
     end
 
     def index
-      links = SingleUseLink.where(itemId: params[:id])
+      links = SingleUseLink.where(itemId: params[:id]).map { |link| show_presenter.new(link) }
       render partial: 'curation_concerns/file_sets/single_use_link_rows', locals: { single_use_links: links }
     end
 

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -35,7 +35,13 @@ module CurationConcerns
     end
 
     def single_use_links
-      @single_use_links ||= SingleUseLink.where(itemId: id)
+      @single_use_links ||= SingleUseLink.where(itemId: id).map { |link| link_presenter_class.new(link) }
     end
+
+    private
+
+      def link_presenter_class
+        CurationConcerns::SingleUseLinkPresenter
+      end
   end
 end

--- a/app/presenters/curation_concerns/single_use_link_presenter.rb
+++ b/app/presenters/curation_concerns/single_use_link_presenter.rb
@@ -1,0 +1,52 @@
+module CurationConcerns
+  class SingleUseLinkPresenter
+    include ActionView::Helpers::TranslationHelper
+
+    attr_reader :link
+
+    delegate :downloadKey, :expired?, :to_param, to: :link
+
+    # @param link [SingleUseLink]
+    def initialize(link)
+      @link = link
+    end
+
+    def human_readable_expiration
+      if hours < 1
+        t('curation_concerns.single_use_links.expiration.lesser_time')
+      else
+        t('curation_concerns.single_use_links.expiration.time', value: hours)
+      end
+    end
+
+    def short_key
+      link.downloadKey.first(6)
+    end
+
+    def link_type
+      if download?
+        t('curation_concerns.single_use_links.download.type')
+      else
+        t('curation_concerns.single_use_links.show.type')
+      end
+    end
+
+    def url_helper
+      if download?
+        "download_single_use_link_url"
+      else
+        "show_single_use_link_url"
+      end
+    end
+
+    private
+
+      def download?
+        link.path =~ /downloads/
+      end
+
+      def hours
+        (link.expires - Time.zone.now).to_i / 3600
+      end
+  end
+end

--- a/app/views/curation_concerns/file_sets/_single_use_link_rows.html.erb
+++ b/app/views/curation_concerns/file_sets/_single_use_link_rows.html.erb
@@ -1,18 +1,18 @@
-<% single_use_links.each_with_index do |link, index| %>
-  <% type = link.path =~ /downloads/ ? 'Download' : 'Show' %>
-  <% url_helper = link.path =~ /downloads/ ? 'download_single_use_link_url' : 'show_single_use_link_url' %>
+<% single_use_links.each do |presenter| %>
   <tr>
-    <td><%= type %></td>
-    <td><%= link.downloadKey %></td>
-    <td><%= link.expires %></td>
+    <td><%= presenter.link_type %></td>
+    <td><%= presenter.downloadKey %></td>
+    <td><%= presenter.human_readable_expiration %></td>
     <td>
       <button class="btn btn-xs btn-default copy-single-use-link"
-              data-clipboard-text="<%= curation_concerns.send(url_helper, link.downloadKey) %>"
-              data-toggle="tooltip" data-placement="bottom" title="Copied!">
-        Copy to Clipboard
+              data-clipboard-text="<%= curation_concerns.send(presenter.url_helper, presenter.downloadKey) %>"
+              data-toggle="tooltip" data-placement="bottom"
+              title="<%= t('curation_concerns.single_use_links.copy.tooltip') %>">
+        <%= t('curation_concerns.single_use_links.copy.button') %>
       </button>
-      <%= link_to "Delete", curation_concerns.delete_single_use_link_path(params[:id], link),
-          class: 'btn btn-xs btn-danger delete-single-use-link' %>
+      <%= link_to t('curation_concerns.single_use_links.delete'),
+                  curation_concerns.delete_single_use_link_path(params[:id], presenter),
+                  class: 'btn btn-xs btn-danger delete-single-use-link' %>
     </td>
   </tr>
 <% end %>

--- a/app/views/curation_concerns/file_sets/_single_use_links.html.erb
+++ b/app/views/curation_concerns/file_sets/_single_use_links.html.erb
@@ -1,11 +1,16 @@
 <table class="table table-striped <%= dom_class(presenter) %> single-use-links">
-  <caption class="table-heading"><h2>Single-Use Links</h2></caption>
+  <caption class="table-heading"><h2><%= t('curation_concerns.single_use_links.title') %></h2></caption>
   <thead>
-    <tr><th>Link</th><th>Key</th><th>Expires</th><th>Actions</th></tr>
+    <tr>
+      <th><%= t('curation_concerns.single_use_links.table.link') %></th>
+      <th><%= t('curation_concerns.single_use_links.table.key') %></th>
+      <th><%= t('curation_concerns.single_use_links.table.expires') %></th>
+      <th><%= t('curation_concerns.single_use_links.table.actions') %></th>
+    </tr>
   </thead>
   <tbody data-url="<%= curation_concerns.generated_single_use_links_path(presenter) %>">
     <% if presenter.single_use_links.empty? %>
-      <tr><td>No links have been generated</td></tr>
+      <tr><td><%= t('curation_concerns.single_use_links.table.no_links') %></td></tr>
     <% else %>
       <%= render 'single_use_link_rows', single_use_links: presenter.single_use_links %>
     <% end %>
@@ -13,8 +18,10 @@
 </table>
 
 <div class="form_actions">
-  <%= link_to "Generate Download Link", curation_concerns.generate_download_single_use_link_path(presenter),
-      class: 'btn btn-default generate-single-use-link' %>
-  <%= link_to "Generate Show Link", curation_concerns.generate_show_single_use_link_path(presenter),
-      class: 'btn btn-default generate-single-use-link' %>
+  <%= link_to t('curation_concerns.single_use_links.download.generate'),
+              curation_concerns.generate_download_single_use_link_path(presenter),
+              class: 'btn btn-default generate-single-use-link' %>
+  <%= link_to t('curation_concerns.single_use_links.show.generate'),
+              curation_concerns.generate_show_single_use_link_path(presenter),
+              class: 'btn btn-default generate-single-use-link' %>
 </div>

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -5,4 +5,4 @@
 <%= media_display @presenter %>
 <%= render "attributes", presenter: @presenter %>
 <%= render "show_actions", presenter: @presenter, parent: parent %>
-<%= render "single_use_links", presenter: @presenter %>
+<%= render "single_use_links", presenter: @presenter if can? :edit, @presenter.id %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -112,6 +112,27 @@ en:
       restricted:
         text: "Private"
         class: "label-danger"
+    single_use_links:
+      title: Single-Use Links
+      table:
+        link: Link
+        key: Key
+        expires: Expires
+        actions: Actions
+        no_links: No links have been generated
+      download: 
+        type: Download
+        generate: Generate Download Link
+      show: 
+        type: Show
+        generate: Generate Show Link
+      copy: 
+        tooltip: Copied!
+        button: Copy to Clipboard
+      delete: Delete
+      expiration:
+        time: "in %{value} hours"
+        lesser_time: in less than one hour
   blacklight:
     search:
       fields:

--- a/spec/controllers/curation_concerns/single_use_links_controller_spec.rb
+++ b/spec/controllers/curation_concerns/single_use_links_controller_spec.rb
@@ -6,6 +6,11 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
   let(:user) { create(:user) }
   let(:file) { create(:file_set, user: user) }
 
+  describe "::show_presenter" do
+    subject { described_class }
+    its(:show_presenter) { is_expected.to eq(CurationConcerns::SingleUseLinkPresenter) }
+  end
+
   describe "logged in user with edit permission" do
     let(:hash) { "some-dummy-sha2-hash" }
 

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -78,10 +78,10 @@ describe CurationConcerns::FileSetPresenter do
     end
   end
 
-  describe "single_use_links" do
-    it "returns ActiveRecord::Relation of all single use links for the file set" do
-      expect(SingleUseLink).to receive(:where).with(itemId: presenter.id)
-      presenter.single_use_links
-    end
+  describe "#single_use_links" do
+    let!(:show_link)     { create(:show_link, itemId: presenter.id) }
+    let!(:download_link) { create(:download_link, itemId: presenter.id) }
+    subject { presenter.single_use_links }
+    it { is_expected.to include(CurationConcerns::SingleUseLinkPresenter) }
   end
 end

--- a/spec/presenters/curation_concerns/single_use_link_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/single_use_link_presenter_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe CurationConcerns::SingleUseLinkPresenter do
+  subject { described_class.new(link) }
+
+  context "with any kind of link" do
+    let(:link) { create(:download_link) }
+
+    describe "#human_readable_expiration" do
+      context "in more than one hour" do
+        its(:human_readable_expiration) { is_expected.to eq("in 23 hours") }
+      end
+      context "in less than an hour" do
+        before { allow(link).to receive(:expires).and_return(Time.zone.now) }
+        its(:human_readable_expiration) { is_expected.to eq("in less than one hour") }
+      end
+    end
+
+    describe "#short_key" do
+      its(:short_key) { is_expected.to eq(link.downloadKey.first(6)) }
+    end
+
+    describe "delegated methods" do
+      its(:downloadKey) { is_expected.to eq(link.downloadKey) }
+      its(:expired?)    { is_expected.to eq(link.expired?) }
+      its(:to_param)    { is_expected.to eq(link.to_param) }
+    end
+  end
+
+  context "with a download link" do
+    let(:link)        { create(:download_link) }
+    its(:link_type)   { is_expected.to eq("Download") }
+    its(:url_helper)  { is_expected.to eq("download_single_use_link_url") }
+  end
+
+  context "with a show link" do
+    let(:link)        { create(:show_link) }
+    its(:link_type)   { is_expected.to eq("Show") }
+    its(:url_helper)  { is_expected.to eq("show_single_use_link_url") }
+  end
+end

--- a/spec/views/curation_concerns/file_sets/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/show.html.erb_spec.rb
@@ -36,130 +36,142 @@ describe 'curation_concerns/file_sets/show.html.erb', type: :view do
 
   before do
     view.lookup_context.prefixes.push 'curation_concerns/base'
-    allow(view).to receive(:can?).with(:edit, String).and_return(true)
     assign(:presenter, presenter)
   end
 
-  describe 'title heading' do
-    before do
-      stub_template 'shared/_brand_bar.html.erb' => 'Brand Bar'
-      stub_template 'shared/_title_bar.html.erb' => 'Title Bar'
-      render template: 'curation_concerns/file_sets/show.html.erb', layout: 'layouts/curation_concerns'
-    end
-    it 'shows the title' do
-      expect(rendered).to have_selector 'h1 > small', text: 'My Title'
+  context "when user does not have edit acces" do
+    before { allow(view).to receive(:can?).with(:edit, String).and_return(false) }
+
+    it "does not show buttons to create links" do
+      expect(rendered).not_to have_link("Generate Download Link")
+      expect(rendered).not_to have_link("Generate Show Link")
     end
   end
 
-  describe 'media display' do
-    context 'when config is true' do
+  context "when the user has edit access" do
+    before { allow(view).to receive(:can?).with(:edit, String).and_return(true) }
+
+    describe 'title heading' do
       before do
-        allow(CurationConcerns.config).to receive(:display_media_download_link) { true }
+        stub_template 'shared/_brand_bar.html.erb' => 'Brand Bar'
+        stub_template 'shared/_title_bar.html.erb' => 'Title Bar'
+        render template: 'curation_concerns/file_sets/show.html.erb', layout: 'layouts/curation_concerns'
+      end
+      it 'shows the title' do
+        expect(rendered).to have_selector 'h1 > small', text: 'My Title'
+      end
+    end
+
+    describe 'media display' do
+      context 'when config is true' do
+        before do
+          allow(CurationConcerns.config).to receive(:display_media_download_link) { true }
+          render
+        end
+
+        context 'with an image' do
+          let(:mime_type) { 'image/tiff' }
+          it 'renders the download link' do
+            expect(rendered).to have_link('Download the full-sized image')
+          end
+        end
+
+        context 'with a PDF' do
+          let(:mime_type) { 'application/pdf' }
+          it 'renders the download link' do
+            expect(rendered).to have_link('Download the full-sized PDF')
+          end
+        end
+
+        context 'with a word document' do
+          let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+          it 'renders the download link' do
+            expect(rendered).to have_link('Download the document')
+          end
+        end
+
+        context 'with anything else' do
+          let(:mime_type) { 'application/binary' }
+          it 'renders the download link' do
+            expect(rendered).to have_link('Download the document')
+          end
+        end
+      end
+
+      context 'when config is false' do
+        before do
+          allow(CurationConcerns.config).to receive(:display_media_download_link) { false }
+          render
+        end
+
+        context 'with an image' do
+          let(:mime_type) { 'image/tiff' }
+          it 'does not render the download link' do
+            expect(rendered).not_to have_link('Download the full-sized image')
+          end
+        end
+
+        context 'with a PDF' do
+          let(:mime_type) { 'application/pdf' }
+          it 'does not render the download link' do
+            expect(rendered).not_to have_link('Download the full-sized PDF')
+          end
+        end
+
+        context 'with a word document' do
+          let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+          it 'does not render the download link' do
+            expect(rendered).not_to have_link('Download the document')
+          end
+        end
+
+        context 'with anything else' do
+          let(:mime_type) { 'application/binary' }
+          it 'does not render the download link' do
+            expect(rendered).not_to have_link('Download the document')
+          end
+        end
+      end
+    end
+
+    describe 'attributes' do
+      before { render }
+
+      it 'shows the description' do
+        expect(rendered).to have_selector '.attribute.description', text: 'Lorem ipsum'
+      end
+    end
+
+    describe 'single use links' do
+      before do
+        allow(presenter).to receive(:single_use_links).and_return(links)
+        controller.params = { id: presenter.id }
         render
       end
 
-      context 'with an image' do
-        let(:mime_type) { 'image/tiff' }
-        it 'renders the download link' do
-          expect(rendered).to have_link('Download the full-sized image')
+      context "when links are present" do
+        let(:show_link)     { CurationConcerns::SingleUseLinkPresenter.new(create(:show_link)) }
+        let(:download_link) { CurationConcerns::SingleUseLinkPresenter.new(create(:download_link)) }
+        let(:links)         { [show_link, download_link] }
+
+        it "renders single use links for the file set" do
+          expect(rendered).to have_selector('td', text: 'Show')
+          expect(rendered).to have_selector('td', text: 'Download')
+          expect(rendered).to have_selector('td', text: show_link.downloadKey)
+          expect(rendered).to have_selector('td', text: "23 hours")
+          expect(rendered).to have_link("Generate Download Link")
+          expect(rendered).to have_link("Generate Show Link")
         end
       end
 
-      context 'with a PDF' do
-        let(:mime_type) { 'application/pdf' }
-        it 'renders the download link' do
-          expect(rendered).to have_link('Download the full-sized PDF')
+      context "when no links are present" do
+        let(:links) { [] }
+
+        it "renders a table without links" do
+          expect(rendered).to have_selector('td', text: 'No links have been generated')
+          expect(rendered).to have_link("Generate Download Link")
+          expect(rendered).to have_link("Generate Show Link")
         end
-      end
-
-      context 'with a word document' do
-        let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
-        it 'renders the download link' do
-          expect(rendered).to have_link('Download the document')
-        end
-      end
-
-      context 'with anything else' do
-        let(:mime_type) { 'application/binary' }
-        it 'renders the download link' do
-          expect(rendered).to have_link('Download the document')
-        end
-      end
-    end
-
-    context 'when config is false' do
-      before do
-        allow(CurationConcerns.config).to receive(:display_media_download_link) { false }
-        render
-      end
-
-      context 'with an image' do
-        let(:mime_type) { 'image/tiff' }
-        it 'does not render the download link' do
-          expect(rendered).not_to have_link('Download the full-sized image')
-        end
-      end
-
-      context 'with a PDF' do
-        let(:mime_type) { 'application/pdf' }
-        it 'does not render the download link' do
-          expect(rendered).not_to have_link('Download the full-sized PDF')
-        end
-      end
-
-      context 'with a word document' do
-        let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
-        it 'does not render the download link' do
-          expect(rendered).not_to have_link('Download the document')
-        end
-      end
-
-      context 'with anything else' do
-        let(:mime_type) { 'application/binary' }
-        it 'does not render the download link' do
-          expect(rendered).not_to have_link('Download the document')
-        end
-      end
-    end
-  end
-
-  describe 'attributes' do
-    before { render }
-
-    it 'shows the description' do
-      expect(rendered).to have_selector '.attribute.description', text: 'Lorem ipsum'
-    end
-  end
-
-  describe 'single use links' do
-    before do
-      allow(presenter).to receive(:single_use_links).and_return(links)
-      controller.params = { id: presenter.id }
-      render
-    end
-
-    context "when links are present" do
-      let(:show_link)     { create(:show_link) }
-      let(:download_link) { create(:download_link) }
-      let(:links)         { [show_link, download_link] }
-
-      it "renders single use links for the file set" do
-        expect(rendered).to have_selector('td', text: 'Show')
-        expect(rendered).to have_selector('td', text: 'Download')
-        expect(rendered).to have_selector('td', text: show_link.downloadKey)
-        expect(rendered).to have_selector('td', text: show_link.expires)
-        expect(rendered).to have_link("Generate Download Link")
-        expect(rendered).to have_link("Generate Show Link")
-      end
-    end
-
-    context "when no links are present" do
-      let(:links) { [] }
-
-      it "renders a table without links" do
-        expect(rendered).to have_selector('td', text: 'No links have been generated')
-        expect(rendered).to have_link("Generate Download Link")
-        expect(rendered).to have_link("Generate Show Link")
       end
     end
   end


### PR DESCRIPTION
Addresses issues raised in projecthydra/sufia#2383

Adds a SingleUseLinkPresenter to encapsulate presentation logic for links, as well as internationalization settings.

@projecthydra/sufia-code-reviewers

