### PR TITLE
Use a longer id for fixtures

### DIFF
--- a/spec/actors/curation_concerns/apply_order_actor_spec.rb
+++ b/spec/actors/curation_concerns/apply_order_actor_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::Actors::ApplyOrderActor do
     end
 
     context 'with ordered_member_ids that are already associated with the parent' do
-      let(:attributes) { { ordered_member_ids: ["Blah"] } }
+      let(:attributes) { { ordered_member_ids: ["BlahBlah1"] } }
       let(:root_actor) { double }
       before do
         allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(root_actor)
@@ -61,7 +61,7 @@ describe CurationConcerns::Actors::ApplyOrderActor do
 
     context 'without an ordered_member_id that was associated with the curation concern' do
       let(:curation_concern) { create(:work_with_two_children, user: user) }
-      let(:attributes) { { ordered_member_ids: ["Blah2"] } }
+      let(:attributes) { { ordered_member_ids: ["BlahBlah2"] } }
       let(:root_actor) { double }
       before do
         allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(root_actor)

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -31,8 +31,8 @@ FactoryGirl.define do
 
     factory :work_with_two_children do
       before(:create) do |work, evaluator|
-        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['A Contained Work'], id: "Blah")
-        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['Another Contained Work'], id: "Blah2")
+        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['A Contained Work'], id: "BlahBlah1")
+        work.ordered_members << FactoryGirl.create(:generic_work, user: evaluator.user, title: ['Another Contained Work'], id: "BlahBlah2")
       end
     end
 


### PR DESCRIPTION

@projecthydra/sufia-code-reviewers

This avoids Fedora from showing errors like this:
```
ERROR 16:29:39.032 (InvalidResourceIdentifierExceptionMapper)
InvalidResourceIdentifierExceptionMapper caught an exception: Path
contains empty element! /test/Bl/ah//l/is/Blah/list_source

ERROR 16:29:39.053 (InvalidResourceIdentifierExceptionMapper)
InvalidResourceIdentifierExceptionMapper caught an exception: Path
contains empty element! /test/Bl/ah//l/is/Blah/list_source
```