### PR TITLE
Cast AC::Parameters to_unsafe_h

### DIFF
--- a/app/actors/curation_concerns/actors/actor_stack.rb
+++ b/app/actors/curation_concerns/actors/actor_stack.rb
@@ -19,14 +19,12 @@ module CurationConcerns
 
       # @param [ActionController::Parameters,Hash,NilClass] new_attributes
       def create(new_attributes)
-        new_attributes ||= {}
-        actor.create(new_attributes.with_indifferent_access)
+        actor.create(cast_to_indifferent_hash(new_attributes))
       end
 
       # @param [ActionController::Parameters,Hash,NilClass] new_attributes
       def update(new_attributes)
-        new_attributes ||= {}
-        actor.update(new_attributes.with_indifferent_access)
+        actor.update(cast_to_indifferent_hash(new_attributes))
       end
 
       def destroy
@@ -37,6 +35,20 @@ module CurationConcerns
         end
         curation_concern.destroy
       end
+
+      private
+
+        # @param [ActionController::Parameters,Hash,NilClass] new_attributes
+        def cast_to_indifferent_hash(new_attributes)
+          new_attributes ||= {}
+          if new_attributes.respond_to?(:to_unsafe_h)
+            # This is the typical (not-ActionView::TestCase) code path.
+            new_attributes = new_attributes.to_unsafe_h
+          end
+          # In Rails 5 to_unsafe_h returns a HashWithIndifferentAccess, in Rails 4 it returns Hash
+          new_attributes = new_attributes.with_indifferent_access if new_attributes.instance_of? Hash
+          new_attributes
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/base_actor.rb
+++ b/app/actors/curation_concerns/actors/base_actor.rb
@@ -53,7 +53,7 @@ module CurationConcerns
         def apply_save_data_to_curation_concern(attributes)
           attributes[:rights] = Array(attributes[:rights]) if attributes.key? :rights
           remove_blank_attributes!(attributes)
-          curation_concern.attributes = attributes.symbolize_keys
+          curation_concern.attributes = attributes
           curation_concern.date_modified = CurationConcerns::TimeService.time_in_utc
         end
 

--- a/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
@@ -197,7 +197,7 @@ module CurationConcerns
       #   search_field: 'all_fields'
       # @return <Hash> the inputs required for the collection member search builder
       def params_for_members_query
-        params.symbolize_keys.merge(q: params[:cq])
+        params.merge(q: params[:cq])
       end
 
       def collection_member_search_builder

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'hydra-head', '>= 10.0.0', '< 11'
+  spec.add_dependency 'active-fedora', '>= 11.0.0.rc6'
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'breadcrumbs_on_rails', '>= 2.3', '< 4'
   spec.add_dependency 'jquery-ui-rails'


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Because `#with_indifferent_access` and `#symbolize_keys` are deprecated
on AC::Parameters