### PR TITLE
Use params keyword with ActionController::TestCase

### DIFF
--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -35,18 +35,16 @@ describe CatalogController do
 
     context 'Searching all works' do
       it 'returns all the works' do
-        get 'index', 'f' => { 'generic_type_sim' => 'Work' }
+        get 'index', params: { 'f' => { 'generic_type_sim' => 'Work' } }
         expect(response).to be_successful
         expect(assigns(:document_list).count).to eq 2
-        [work1.id, work2.id].each do |work_id|
-          expect(assigns(:document_list).map(&:id)).to include(work_id)
-        end
+        expect(assigns(:document_list).map(&:id)).to include(work1.id, work2.id)
       end
     end
 
     context 'Searching all collections' do
       it 'returns all the works' do
-        get 'index', 'f' => { 'generic_type_sim' => 'Collection' }
+        get 'index', params: { 'f' => { 'generic_type_sim' => 'Collection' } }
         expect(response).to be_successful
         expect(assigns(:document_list).map(&:id)).to eq [collection.id]
       end
@@ -54,7 +52,7 @@ describe CatalogController do
 
     context 'searching just my works' do
       it 'returns just my works' do
-        get 'index', works: 'mine', 'f' => { 'generic_type_sim' => 'Work' }
+        get 'index', params: { works: 'mine', 'f' => { 'generic_type_sim' => 'Work' } }
         expect(response).to be_successful
         expect(assigns(:document_list).map(&:id)).to eq [work1.id]
       end
@@ -62,7 +60,7 @@ describe CatalogController do
 
     context 'searching for one kind of work' do
       it 'returns just the specified type' do
-        get 'index', 'f' => { 'human_readable_type_sim' => 'Generic Work' }
+        get 'index', params: { 'f' => { 'human_readable_type_sim' => 'Generic Work' } }
         expect(response).to be_successful
         expect(assigns(:document_list).map(&:id)).to include(work1.id, work2.id)
       end
@@ -72,7 +70,7 @@ describe CatalogController do
       let!(:work) { FactoryGirl.create(:generic_work, user: user, title: ["All my #{srand}"]) }
       render_views
       it 'returns json' do
-        xhr :get, :index, format: :json, q: work.title.first
+        get :index, xhr: true, params: { format: :json, q: work.title.first }
         json = JSON.parse(response.body)
         # Grab the doc corresponding to work and inspect the json
         work_json = json['docs'].first
@@ -95,17 +93,17 @@ describe CatalogController do
 
     context 'searching all works' do
       it "returns other users' private works" do
-        get 'index', 'f' => { 'generic_type_sim' => 'Work' }
+        get 'index', params: { 'f' => { 'generic_type_sim' => 'Work' } }
         expect(response).to be_successful
         expect(assigns(:document_list).map(&:id)).to include(work1.id)
       end
       it "returns other users' embargoed works" do
-        get 'index', 'f' => { 'generic_type_sim' => 'Work' }
+        get 'index', params: { 'f' => { 'generic_type_sim' => 'Work' } }
         expect(response).to be_successful
         expect(assigns(:document_list).map(&:id)).to include(work2.id)
       end
       it "returns other users' private collections" do
-        get 'index', 'f' => { 'generic_type_sim' => 'Collection' }
+        get 'index', params: { 'f' => { 'generic_type_sim' => 'Collection' } }
         expect(response).to be_successful
         expect(assigns(:document_list).map(&:id)).to include(collection.id)
       end

--- a/spec/controllers/curation_concerns/classify_concerns_controller_spec.rb
+++ b/spec/controllers/curation_concerns/classify_concerns_controller_spec.rb
@@ -19,7 +19,7 @@ describe CurationConcerns::ClassifyConcernsController do
   describe '#create' do
     context 'without logging in' do
       it 'redirect to login page if user is not logged in' do
-        post :create, classify: { curation_concern_type: 'GenericWork' }
+        post :create, params: { classify: { curation_concern_type: 'GenericWork' } }
         expect(response).to redirect_to(main_app.user_session_path)
       end
     end
@@ -34,7 +34,7 @@ describe CurationConcerns::ClassifyConcernsController do
       let(:new_curation_concern_generic_work_path) { '/stub/path' }
 
       it 'requires authentication' do
-        post :create, classify_concern: { curation_concern_type: 'GenericWork' }
+        post :create, params: { classify_concern: { curation_concern_type: 'GenericWork' } }
         expect(response).to redirect_to(main_app.new_curation_concerns_generic_work_path)
       end
     end

--- a/spec/controllers/curation_concerns/generic_works_controller_json_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_json_spec.rb
@@ -8,7 +8,7 @@ describe CurationConcerns::GenericWorksController do
 
   context "JSON" do
     let(:resource) { create(:private_generic_work, user: user) }
-    let(:resource_request) { get :show, id: resource, format: :json }
+    let(:resource_request) { get :show, params: { id: resource, format: :json } }
     subject { response }
 
     describe "unauthorized" do
@@ -28,12 +28,12 @@ describe CurationConcerns::GenericWorksController do
     end
 
     describe 'not found' do
-      before { get :show, id: "non-existent-pid", format: :json }
+      before { get :show, params: { id: "non-existent-pid", format: :json } }
       it { is_expected.to respond_not_found }
     end
 
     describe 'created' do
-      before { post :create, generic_work: { title: ['a title'] }, format: :json }
+      before { post :create, params: { generic_work: { title: ['a title'] }, format: :json } }
       it "returns 201, renders show template sets location header" do
         # Ensure that @curation_concern is set for jbuilder template to use
         expect(assigns[:curation_concern]).to be_instance_of GenericWork
@@ -45,7 +45,7 @@ describe CurationConcerns::GenericWorksController do
     end
 
     describe 'failed create' do
-      before { post :create, generic_work: {}, format: :json }
+      before { post :create, params: { generic_work: {}, format: :json } }
       it "returns 422 and the errors" do
         created_resource = assigns[:curation_concern]
         expect(response).to respond_unprocessable_entity(errors: created_resource.errors.messages.as_json)
@@ -63,7 +63,7 @@ describe CurationConcerns::GenericWorksController do
     end
 
     describe 'updated' do
-      before { put :update, id: resource, generic_work: { title: ['updated title'] }, format: :json }
+      before { put :update, params: { id: resource, generic_work: { title: ['updated title'] }, format: :json } }
       it "returns 200, renders show template sets location header" do
         # Ensure that @curation_concern is set for jbuilder template to use
         expect(assigns[:curation_concern]).to be_instance_of GenericWork
@@ -76,7 +76,7 @@ describe CurationConcerns::GenericWorksController do
 
     describe 'failed update' do
       before do
-        post :update, id: resource, generic_work: { title: [''] }, format: :json
+        post :update, params: { id: resource, generic_work: { title: [''] }, format: :json }
       end
       it "returns 422 and the errors" do
         expect(response).to respond_unprocessable_entity(errors: { title: ["Your work must have a title."] })

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -10,7 +10,7 @@ describe CurationConcerns::GenericWorksController do
     context 'my own private work' do
       let(:work) { create(:private_generic_work, user: user) }
       it 'shows me the page' do
-        get :show, id: work
+        get :show, params: { id: work }
         expect(response).to be_success
       end
 
@@ -18,8 +18,7 @@ describe CurationConcerns::GenericWorksController do
         render_views
         it "renders a breadcrumb" do
           parent = create(:generic_work, title: ['Parent Work'], user: user, ordered_members: [work])
-          get :show, id: work, parent_id: parent
-
+          get :show, params: { id: work, parent_id: parent }
           expect(response.body).to have_content "Parent Work"
         end
       end
@@ -28,7 +27,7 @@ describe CurationConcerns::GenericWorksController do
     context 'someone elses private work' do
       let(:work) { create(:private_generic_work) }
       it 'shows unauthorized message' do
-        get :show, id: work
+        get :show, params: { id: work }
         expect(response.code).to eq '401'
         expect(response).to render_template(:unauthorized)
       end
@@ -39,7 +38,7 @@ describe CurationConcerns::GenericWorksController do
       context "html" do
         it 'shows me the page' do
           expect(controller). to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
-          get :show, id: work
+          get :show, params: { id: work }
           expect(response).to be_success
         end
       end
@@ -52,7 +51,7 @@ describe CurationConcerns::GenericWorksController do
         end
 
         it 'renders an turtle file' do
-          get :show, id: '99999999', format: :ttl
+          get :show, params: { id: '99999999', format: :ttl }
           expect(response).to be_successful
           expect(response.body).to eq "ttl graph"
           expect(response.content_type).to eq 'text/turtle'
@@ -64,7 +63,7 @@ describe CurationConcerns::GenericWorksController do
       before { allow_any_instance_of(User).to receive(:groups).and_return(['admin']) }
       let(:work) { create(:private_generic_work) }
       it 'someone elses private work should show me the page' do
-        get :show, id: work
+        get :show, params: { id: work }
         expect(response).to be_success
       end
     end
@@ -73,7 +72,7 @@ describe CurationConcerns::GenericWorksController do
       it 'returns 404 page' do
         allow(controller).to receive(:show).and_raise(ActiveFedora::ObjectNotFoundError)
         expect(controller).to receive(:render_404) { controller.render nothing: true }
-        get :show, id: 'abc123'
+        get :show, params: { id: 'abc123' }
       end
     end
   end
@@ -99,7 +98,7 @@ describe CurationConcerns::GenericWorksController do
       let(:work) { stub_model(GenericWork) }
       it 'creates a work' do
         allow(controller).to receive(:curation_concern).and_return(work)
-        post :create, generic_work: { title: ['a title'] }
+        post :create, params: { generic_work: { title: ['a title'] } }
         expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
       end
     end
@@ -107,7 +106,7 @@ describe CurationConcerns::GenericWorksController do
     context 'when create fails' do
       let(:create_status) { false }
       it 'draws the form again' do
-        post :create, generic_work: { title: ['a title'] }
+        post :create, params: { generic_work: { title: ['a title'] } }
         expect(response.status).to eq 422
         expect(assigns[:form]).to be_kind_of CurationConcerns::GenericWorkForm
         expect(response).to render_template 'new'
@@ -118,7 +117,7 @@ describe CurationConcerns::GenericWorksController do
       before { allow(controller.current_ability).to receive(:can?).and_return(false) }
 
       it 'shows the unauthorized message' do
-        post :create, generic_work: { title: ['a title'] }
+        post :create, params: { generic_work: { title: ['a title'] } }
         expect(response.code).to eq '401'
         expect(response).to render_template(:unauthorized)
       end
@@ -129,7 +128,7 @@ describe CurationConcerns::GenericWorksController do
     context 'my own private work' do
       let(:work) { create(:private_generic_work, user: user) }
       it 'shows me the page' do
-        get :edit, id: work
+        get :edit, params: { id: work }
         expect(assigns[:form]).to be_kind_of CurationConcerns::GenericWorkForm
         expect(response).to be_success
       end
@@ -139,7 +138,7 @@ describe CurationConcerns::GenericWorksController do
       routes { Rails.application.class.routes }
       let(:work) { create(:private_generic_work) }
       it 'shows the unauthorized message' do
-        get :edit, id: work
+        get :edit, params: { id: work }
         expect(response.code).to eq '401'
         expect(response).to render_template(:unauthorized)
       end
@@ -148,7 +147,7 @@ describe CurationConcerns::GenericWorksController do
     context 'someone elses public work' do
       let(:work) { create(:public_generic_work) }
       it 'shows the unauthorized message' do
-        get :edit, id: work
+        get :edit, params: { id: work }
         expect(response.code).to eq '401'
         expect(response).to render_template(:unauthorized)
       end
@@ -158,7 +157,7 @@ describe CurationConcerns::GenericWorksController do
       before { allow_any_instance_of(User).to receive(:groups).and_return(['admin']) }
       let(:work) { create(:private_generic_work) }
       it 'someone elses private work should show me the page' do
-        get :edit, id: work
+        get :edit, params: { id: work }
         expect(response).to be_success
       end
     end
@@ -166,20 +165,20 @@ describe CurationConcerns::GenericWorksController do
 
   describe '#update' do
     let(:work) { create(:private_generic_work, user: user) }
+    let(:visibility_changed) { false }
+    let(:actor) { double(update: true) }
     before do
       allow(CurationConcerns::CurationConcern).to receive(:actor).and_return(actor)
       allow_any_instance_of(GenericWork).to receive(:visibility_changed?).and_return(visibility_changed)
     end
-    let(:visibility_changed) { false }
-    let(:actor) { double(update: true) }
 
     it 'updates the work' do
-      patch :update, id: work, generic_work: {}
+      patch :update, params: { id: work, generic_work: {} }
       expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
     end
 
     it "can update file membership" do
-      patch :update, id: work, generic_work: { ordered_member_ids: ['foo_123'] }
+      patch :update, params: { id: work, generic_work: { ordered_member_ids: ['foo_123'] } }
       expected_params = { ordered_member_ids: ['foo_123'] }
       if Rails.version < '5.0.0'
         expect(actor).to have_received(:update).with(expected_params)
@@ -196,14 +195,14 @@ describe CurationConcerns::GenericWorksController do
         let(:work) { create(:work_with_one_file, user: user) }
 
         it 'prompts to change the files access' do
-          patch :update, id: work, generic_work: {}
+          patch :update, params: { id: work, generic_work: {} }
           expect(response).to redirect_to main_app.confirm_curation_concerns_permission_path(controller.curation_concern)
         end
       end
 
       context 'without children' do
         it "doesn't prompt to change the files access" do
-          patch :update, id: work, generic_work: {}
+          patch :update, params: { id: work, generic_work: {} }
           expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
         end
       end
@@ -213,7 +212,7 @@ describe CurationConcerns::GenericWorksController do
       let(:actor) { double(update: false) }
 
       it 'renders the form' do
-        patch :update, id: work, generic_work: {}
+        patch :update, params: { id: work, generic_work: {} }
         expect(assigns[:form]).to be_kind_of CurationConcerns::GenericWorkForm
         expect(response).to render_template('edit')
       end
@@ -222,7 +221,7 @@ describe CurationConcerns::GenericWorksController do
     context 'someone elses public work' do
       let(:work) { create(:public_generic_work) }
       it 'shows the unauthorized message' do
-        get :update, id: work
+        get :update, params: { id: work }
         expect(response.code).to eq '401'
         expect(response).to render_template(:unauthorized)
       end
@@ -232,7 +231,7 @@ describe CurationConcerns::GenericWorksController do
       before { allow_any_instance_of(User).to receive(:groups).and_return(['admin']) }
       let(:work) { create(:private_generic_work) }
       it 'someone elses private work should update the work' do
-        patch :update, id: work, generic_work: {}
+        patch :update, params: { id: work, generic_work: {} }
         expect(response).to redirect_to main_app.curation_concerns_generic_work_path(work)
       end
     end
@@ -243,7 +242,7 @@ describe CurationConcerns::GenericWorksController do
     let(:parent_collection) { create(:collection) }
 
     it 'deletes the work' do
-      delete :destroy, id: work_to_be_deleted
+      delete :destroy, params: { id: work_to_be_deleted }
       expect(response).to redirect_to main_app.search_catalog_path
       expect(GenericWork).not_to exist(work_to_be_deleted.id)
     end
@@ -254,7 +253,7 @@ describe CurationConcerns::GenericWorksController do
         parent_collection.save!
       end
       it 'deletes the work and updates the parent collection' do
-        delete :destroy, id: work_to_be_deleted
+        delete :destroy, params: { id: work_to_be_deleted }
         expect(GenericWork).not_to exist(work_to_be_deleted.id)
         expect(response).to redirect_to main_app.search_catalog_path
         expect(parent_collection.reload.members).to eq []
@@ -264,13 +263,13 @@ describe CurationConcerns::GenericWorksController do
     it "invokes the after_destroy callback" do
       expect(CurationConcerns.config.callback).to receive(:run)
         .with(:after_destroy, work_to_be_deleted.id, user)
-      delete :destroy, id: work_to_be_deleted
+      delete :destroy, params: { id: work_to_be_deleted }
     end
 
     context 'someone elses public work' do
       let(:work_to_be_deleted) { create(:private_generic_work) }
       it 'shows unauthorized message' do
-        delete :destroy, id: work_to_be_deleted
+        delete :destroy, params: { id: work_to_be_deleted }
         expect(response.code).to eq '401'
         expect(response).to render_template(:unauthorized)
       end
@@ -280,7 +279,7 @@ describe CurationConcerns::GenericWorksController do
       let(:work_to_be_deleted) { create(:private_generic_work) }
       before { allow_any_instance_of(User).to receive(:groups).and_return(['admin']) }
       it 'someone elses private work should delete the work' do
-        delete :destroy, id: work_to_be_deleted
+        delete :destroy, params: { id: work_to_be_deleted }
         expect(GenericWork).not_to exist(work_to_be_deleted.id)
       end
     end
@@ -288,12 +287,8 @@ describe CurationConcerns::GenericWorksController do
 
   describe '#file_manager' do
     let(:work) { create(:private_generic_work, user: user) }
-    before do
-      sign_in user
-    end
     it "is successful" do
-      get :file_manager, id: work.id
-
+      get :file_manager, params: { id: work.id }
       expect(response).to be_success
       expect(assigns(:presenter)).not_to be_blank
     end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -71,7 +71,7 @@ describe CurationConcerns::GenericWorksController do
     context 'when a ObjectNotFoundError is raised' do
       it 'returns 404 page' do
         allow(controller).to receive(:show).and_raise(ActiveFedora::ObjectNotFoundError)
-        expect(controller).to receive(:render_404) { controller.render nothing: true }
+        expect(controller).to receive(:render_404) { controller.render body: nil }
         get :show, params: { id: 'abc123' }
       end
     end

--- a/spec/controllers/curation_concerns/operations_controller_spec.rb
+++ b/spec/controllers/curation_concerns/operations_controller_spec.rb
@@ -12,7 +12,7 @@ describe CurationConcerns::OperationsController do
 
   describe "#index" do
     it "is successful" do
-      get :index, user_id: user
+      get :index, params: { user_id: user }
       expect(response).to be_successful
       expect(assigns[:operations]).to eq [parent]
     end
@@ -20,7 +20,7 @@ describe CurationConcerns::OperationsController do
 
   describe "#show" do
     it "is successful" do
-      get :show, user_id: user, id: parent
+      get :show, params: { user_id: user, id: parent }
       expect(response).to be_successful
       expect(assigns[:operation]).to eq parent
     end

--- a/spec/controllers/curation_concerns/permissions_controller_spec.rb
+++ b/spec/controllers/curation_concerns/permissions_controller_spec.rb
@@ -8,7 +8,7 @@ describe CurationConcerns::PermissionsController do
     let(:generic_work) { create(:generic_work, user: user) }
 
     it 'draws the page' do
-      get :confirm, id: generic_work
+      get :confirm, params: { id: generic_work }
       expect(response).to be_success
     end
   end
@@ -18,7 +18,7 @@ describe CurationConcerns::PermissionsController do
 
     it 'adds a worker to the queue' do
       expect(VisibilityCopyJob).to receive(:perform_later).with(generic_work)
-      post :copy, id: generic_work
+      post :copy, params: { id: generic_work }
       expect(response).to redirect_to main_app.curation_concerns_generic_work_path(generic_work)
       expect(flash[:notice]).to eq 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
     end

--- a/spec/controllers/curation_concerns/single_use_links_controller_spec.rb
+++ b/spec/controllers/curation_concerns/single_use_links_controller_spec.rb
@@ -24,7 +24,7 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
 
       describe "creating a single-use download link" do
         it "returns a link for downloading" do
-          post 'create_download', id: file
+          post 'create_download', params: { id: file }
           expect(response).to be_success
           expect(response.body).to eq download_single_use_link_url(hash)
         end
@@ -32,7 +32,7 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
 
       describe "creating a single-use show link" do
         it "returns a link for showing" do
-          post 'create_show', id: file
+          post 'create_show', params: { id: file }
           expect(response).to be_success
           expect(response.body).to eq show_single_use_link_url(hash)
         end
@@ -41,7 +41,7 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
 
     context "GET index" do
       describe "viewing existing links" do
-        before { get :index, id: file }
+        before { get :index, params: { id: file } }
         subject { response }
         it { is_expected.to be_success }
       end
@@ -50,7 +50,7 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
     context "DELETE destroy" do
       let!(:link) { create(:download_link) }
       it "deletes the link" do
-        expect { delete :destroy, id: file, link_id: link }.to change { SingleUseLink.count }.by(-1)
+        expect { delete :destroy, params: { id: file, link_id: link } }.to change { SingleUseLink.count }.by(-1)
         expect(response).to be_success
       end
     end
@@ -64,17 +64,17 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
     subject { response }
 
     describe "creating a single-use download link" do
-      before { post 'create_download', id: file }
+      before { post 'create_download', params: { id: file } }
       it { is_expected.not_to be_success }
     end
 
     describe "creating a single-use show link" do
-      before { post 'create_show', id: file }
+      before { post 'create_show', params: { id: file } }
       it { is_expected.not_to be_success }
     end
 
     describe "viewing existing links" do
-      before { get :index, id: file }
+      before { get :index, params: { id: file } }
       it { is_expected.not_to be_success }
     end
   end
@@ -83,17 +83,17 @@ describe CurationConcerns::SingleUseLinksController, type: :controller do
     subject { response }
 
     describe "creating a single-use download link" do
-      before { post 'create_download', id: file }
+      before { post 'create_download', params: { id: file } }
       it { is_expected.not_to be_success }
     end
 
     describe "creating a single-use show link" do
-      before { post 'create_show', id: file }
+      before { post 'create_show', params: { id: file } }
       it { is_expected.not_to be_success }
     end
 
     describe "viewing existing links" do
-      before { get :index, id: file }
+      before { get :index, params: { id: file } }
       it { is_expected.not_to be_success }
     end
   end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -8,16 +8,15 @@ describe DownloadsController do
     end
     it 'calls render_404 if the object does not exist' do
       expect(controller).to receive(:render_404) { controller.render nothing: true }
-      get :show, id: '8675309'
+      get :show, params: { id: '8675309' }
     end
 
     context "when user doesn't have access" do
       let(:another_user) { FactoryGirl.create(:user) }
-      before do
-        sign_in another_user
-      end
+      before { sign_in another_user }
+
       it 'redirects to root' do
-        get :show, id: file_set.to_param
+        get :show, params: { id: file_set.to_param }
         expect(response).to redirect_to root_path
         expect(flash['alert']).to eq 'You are not authorized to access this page.'
       end
@@ -25,31 +24,28 @@ describe DownloadsController do
 
     context "when user isn't logged in" do
       it 'redirects to sign in' do
-        get :show, id: file_set.to_param
+        get :show, params: { id: file_set.to_param }
         expect(response).to redirect_to new_user_session_path
         expect(flash['alert']).to eq 'You are not authorized to access this page.'
       end
 
       it 'authorizes the resource using only the id' do
         expect(controller).to receive(:authorize!).with(:read, file_set.id)
-        get :show, id: file_set.to_param
+        get :show, params: { id: file_set.to_param }
       end
     end
 
     context "when the user has access" do
-      before do
-        sign_in user
-      end
+      before { sign_in user }
 
       it 'sends the original file' do
-        get :show, id: file_set
+        get :show, params: { id: file_set }
         expect(response.body).to eq file_set.original_file.content
       end
 
       context "with an alternative file" do
         context "that is persisted" do
           let(:file) { File.open(fixture_file_path('world.png'), 'rb') }
-
           let(:content) { file.read }
 
           before do
@@ -57,7 +53,7 @@ describe DownloadsController do
           end
 
           it 'sends requested file content' do
-            get :show, id: file_set, file: 'thumbnail'
+            get :show, params: { id: file_set, file: 'thumbnail' }
             expect(response.body).to eq content
             expect(response.headers['Content-Length']).to eq "4218"
             expect(response.headers['Accept-Ranges']).to eq "bytes"
@@ -65,21 +61,21 @@ describe DownloadsController do
 
           it 'retrieves the thumbnail without contacting Fedora' do
             expect(ActiveFedora::Base).not_to receive(:find).with(file_set.id)
-            get :show, id: file_set, file: 'thumbnail'
+            get :show, params: { id: file_set, file: 'thumbnail' }
           end
         end
 
         context "that isn't persisted" do
           it "returns 404 if the requested file does not exist" do
             expect(controller).to receive(:render_404) { controller.render nothing: true }
-            get :show, id: file_set, file: 'thumbnail'
+            get :show, params: { id: file_set, file: 'thumbnail' }
           end
         end
       end
 
       it "returns 404 if the requested association does not exist" do
         expect(controller).to receive(:render_404) { controller.render nothing: true }
-        get :show, id: file_set, file: 'non-existant'
+        get :show, params: { id: file_set, file: 'non-existant' }
       end
     end
   end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -7,7 +7,7 @@ describe DownloadsController do
       FactoryGirl.create(:file_with_work, user: user, content: File.open(fixture_file_path('files/image.png')))
     end
     it 'calls render_404 if the object does not exist' do
-      expect(controller).to receive(:render_404) { controller.render nothing: true }
+      expect(controller).to receive(:render_404) { controller.render body: nil }
       get :show, params: { id: '8675309' }
     end
 
@@ -67,14 +67,14 @@ describe DownloadsController do
 
         context "that isn't persisted" do
           it "returns 404 if the requested file does not exist" do
-            expect(controller).to receive(:render_404) { controller.render nothing: true }
+            expect(controller).to receive(:render_404) { controller.render body: nil }
             get :show, params: { id: file_set, file: 'thumbnail' }
           end
         end
       end
 
       it "returns 404 if the requested association does not exist" do
-        expect(controller).to receive(:render_404) { controller.render nothing: true }
+        expect(controller).to receive(:render_404) { controller.render body: nil }
         get :show, params: { id: file_set, file: 'non-existant' }
       end
     end

--- a/spec/controllers/embargoes_controller_spec.rb
+++ b/spec/controllers/embargoes_controller_spec.rb
@@ -26,14 +26,14 @@ describe EmbargoesController do
   describe '#edit' do
     context 'when I do not have edit permissions for the object' do
       it 'redirects' do
-        get :edit, id: not_my_work
+        get :edit, params: { id: not_my_work }
         expect(response.status).to eq 302
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
     context 'when I have permission to edit the object' do
       it 'shows me the page' do
-        get :edit, id: a_work
+        get :edit, params: { id: a_work }
         expect(response).to be_success
       end
     end
@@ -42,7 +42,7 @@ describe EmbargoesController do
   describe '#destroy' do
     context 'when I do not have edit permissions for the object' do
       it 'denies access' do
-        get :destroy, id: not_my_work
+        get :destroy, params: { id: not_my_work }
         expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
       end
     end
@@ -57,7 +57,7 @@ describe EmbargoesController do
       context 'that has no files' do
         it 'deactivates embargo and redirects' do
           expect(actor).to receive(:destroy)
-          get :destroy, id: a_work
+          get :destroy, params: { id: a_work }
           expect(response).to redirect_to edit_embargo_path(a_work)
         end
       end
@@ -70,7 +70,7 @@ describe EmbargoesController do
 
         it 'deactivates embargo and checks to see if we want to copy the visibility to files' do
           expect(actor).to receive(:destroy)
-          get :destroy, id: a_work
+          get :destroy, params: { id: a_work }
           expect(response).to redirect_to confirm_curation_concerns_permission_path(a_work)
         end
       end
@@ -94,7 +94,7 @@ describe EmbargoesController do
       context 'with an expired embargo' do
         let(:release_date) { Date.today - 2 }
         it 'deactivates embargo, update the visibility and redirect' do
-          patch :update, batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } }
+          patch :update, params: { batch_document_ids: [a_work.id], embargoes: { '0' => { copy_visibility: a_work.id } } }
           expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           expect(response).to redirect_to embargoes_path

--- a/spec/controllers/leases_controller_spec.rb
+++ b/spec/controllers/leases_controller_spec.rb
@@ -26,14 +26,14 @@ describe LeasesController do
   describe '#edit' do
     context 'when I do not have edit permissions for the object' do
       it 'redirects' do
-        get :edit, id: not_my_work
+        get :edit, params: { id: not_my_work }
         expect(response.status).to eq 302
         expect(flash[:alert]).to eq 'You are not authorized to access this page.'
       end
     end
     context 'when I have permission to edit the object' do
       it 'shows me the page' do
-        get :edit, id: a_work
+        get :edit, params: { id: a_work }
         expect(response).to be_success
       end
     end
@@ -42,7 +42,7 @@ describe LeasesController do
   describe '#destroy' do
     context 'when I do not have edit permissions for the object' do
       it 'denies access' do
-        get :destroy, id: not_my_work
+        get :destroy, params: { id: not_my_work }
         expect(response).to fail_redirect_and_flash(root_path, 'You are not authorized to access this page.')
       end
     end
@@ -56,7 +56,7 @@ describe LeasesController do
       context 'that has no files' do
         it 'deactivates the lease and redirects' do
           expect(actor).to receive(:destroy)
-          get :destroy, id: a_work
+          get :destroy, params: { id: a_work }
           expect(response).to redirect_to edit_lease_path(a_work)
         end
       end
@@ -69,7 +69,7 @@ describe LeasesController do
 
         it 'deactivates the lease and redirects' do
           expect(actor).to receive(:destroy)
-          get :destroy, id: a_work
+          get :destroy, params: { id: a_work }
           expect(response).to redirect_to confirm_curation_concerns_permission_path(a_work)
         end
       end
@@ -94,7 +94,7 @@ describe LeasesController do
       context 'with an expired lease' do
         let(:expiration_date) { Date.today - 2 }
         it 'deactivates lease, update the visibility and redirect' do
-          patch :update, batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } }
+          patch :update, params: { batch_document_ids: [a_work.id], leases: { '0' => { copy_visibility: a_work.id } } }
           expect(a_work.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
           expect(file_set.reload.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
           expect(response).to redirect_to leases_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,7 @@ RSpec.configure do |config|
   config.include(ControllerLevelHelpers, type: :view)
   config.before(:each, type: :view) { initialize_controller_helpers(view) }
 
+  config.include BackportTest, type: :controller unless Rails.version > '5'
   config.include Controllers::EngineHelpers, type: :controller
   config.include Controllers::EngineHelpers, type: :helper
   config.include ::Rails.application.routes.url_helpers

--- a/spec/support/backport_test.rb
+++ b/spec/support/backport_test.rb
@@ -1,0 +1,14 @@
+# Backport the Rails 5 controller test methods to Rails 4
+module BackportTest
+  [:delete, :get, :post, :put, :patch].each do |http_action|
+    define_method(http_action) do |*args|
+      (action, rest) = *args
+      rest ||= {}
+      if rest[:xhr]
+        @request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+        @request.env['HTTP_ACCEPT'] ||= [Mime::JS, Mime::HTML, Mime::XML, 'text/xml', Mime::ALL].join(', ')
+      end
+      super(action, rest[:params])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #910
Fixes #907 
Largely fixes #905.  Remaining TestCase warnings are from a helper class.

Saves hundreds of lines of deprecation warnings per CI run.

Converts `xhr` calls to their corresponding HTTP method with `xhr: true`.  (#910)