### PR TITLE
Add sortable_placeholder from plum, fixes #915

### DIFF
--- a/app/assets/javascripts/curation_concerns/file_manager.es6
+++ b/app/assets/javascripts/curation_concerns/file_manager.es6
@@ -7,6 +7,7 @@ export default class FileManager {
     this.sorting()
     this.save_affix()
     this.member_tracking()
+    this.sortable_placeholder()
   }
 
   initialize_save_manager() {
@@ -36,6 +37,19 @@ export default class FileManager {
     $("li[data-reorder-id]").each(function(index, element) {
       var manager_member = new FileManagerMember($(element), sm)
       $(element).data("file_manager_member", manager_member)
+    })
+  }
+
+  // Keep the ui/sortable placeholder the right size.
+  // This keeps the grid a consistent height so when the
+  // last row contains 1 object,
+  // - an element can be moved into the last spot, and
+  // - the footer doesn't jump up.
+  sortable_placeholder() {
+    $( "#sortable" ).on( "sortstart", function( event, ui ) {
+      let found_element = $("#sortable").children("li[data-reorder-id]").first()
+      ui.placeholder.width(found_element.width())
+      ui.placeholder.height(found_element.height())
     })
   }
 }


### PR DESCRIPTION
Creates a space when you drag an object in the file-manager so you can put an object in the last position. also keeps footer from jumping up when there was just 1 object in the final row.