### PR TITLE
Adding characterization terms to the solr indexes and to the FileSet presenter

### DIFF
--- a/app/indexers/curation_concerns/file_set_indexer.rb
+++ b/app/indexers/curation_concerns/file_set_indexer.rb
@@ -22,6 +22,11 @@ module CurationConcerns
         # between files on disk (in fcrepo.binary-store-path) and objects
         # in the repository.
         solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
+        solr_doc[Solrizer.solr_name('page_count')] = object.page_count
+        solr_doc[Solrizer.solr_name('file_title')] = object.file_title
+        solr_doc[Solrizer.solr_name('duration')] = object.duration
+        solr_doc[Solrizer.solr_name('sample_rate')] = object.sample_rate
+        solr_doc[Solrizer.solr_name('original_checksum')] = object.original_checksum
       end
     end
 

--- a/app/models/concerns/curation_concerns/file_set/characterization.rb
+++ b/app/models/concerns/curation_concerns/file_set/characterization.rb
@@ -19,7 +19,8 @@ module CurationConcerns
         class_attribute :characterization_terms, :characterization_proxy
         self.characterization_terms = [
           :format_label, :file_size, :height, :width, :filename, :well_formed,
-          :page_count, :file_title, :last_modified, :original_checksum, :mime_type
+          :page_count, :file_title, :last_modified, :original_checksum, :mime_type,
+          :duration, :sample_rate
         ]
         self.characterization_proxy = :original_file
 

--- a/app/models/concerns/curation_concerns/solr_behavior/characterization.rb
+++ b/app/models/concerns/curation_concerns/solr_behavior/characterization.rb
@@ -1,0 +1,106 @@
+module CurationConcerns
+  module SolrBehavior
+    # TODO: aside from height and width, I don't think any of these other terms are indexed by default. - Justin 3/2016
+    module Characterization
+      def format_label
+        self[Solrizer.solr_name("format_label")]
+      end
+
+      def file_size
+        self[Solrizer.solr_name("file_size")]
+      end
+
+      def filename
+        self[Solrizer.solr_name("filename")]
+      end
+
+      def well_formed
+        self[Solrizer.solr_name("well_formed")]
+      end
+
+      def byte_order
+        self[Solrizer.solr_name("byte_order")]
+      end
+
+      def capture_device
+        self[Solrizer.solr_name("capture_device")]
+      end
+
+      def color_map
+        self[Solrizer.solr_name("color_map")]
+      end
+
+      def color_space
+        self[Solrizer.solr_name("color_space")]
+      end
+
+      def compression
+        self[Solrizer.solr_name("compression")]
+      end
+
+      def gps_timestamp
+        self[Solrizer.solr_name("gps_timestamp")]
+      end
+
+      def height
+        self['height_is']
+      end
+
+      def image_producer
+        self[Solrizer.solr_name("image_producer")]
+      end
+
+      def latitude
+        self[Solrizer.solr_name("latitude")]
+      end
+
+      def longitude
+        self[Solrizer.solr_name("longitude")]
+      end
+
+      def orientation
+        self[Solrizer.solr_name("orientation")]
+      end
+
+      def profile_name
+        self[Solrizer.solr_name("profile_name")]
+      end
+
+      def profile_version
+        self[Solrizer.solr_name("profile_version")]
+      end
+
+      def scanning_software
+        self[Solrizer.solr_name("scanning_software")]
+      end
+
+      def width
+        self['width_is']
+      end
+
+      def page_count
+        self[Solrizer.solr_name("page_count")]
+      end
+
+      def file_title
+        self[Solrizer.solr_name("file_title")]
+      end
+
+      def duration
+        self[Solrizer.solr_name("duration")]
+      end
+
+      def sample_rate
+        self[Solrizer.solr_name("sample_rate")]
+      end
+
+      def last_modified
+        self[Solrizer.solr_name("last_modified")]
+      end
+
+      def original_checksum
+        self[Solrizer.solr_name("original_checksum")]
+      end
+    end
+  end
+end

--- a/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -2,6 +2,7 @@ module CurationConcerns
   module SolrDocumentBehavior
     extend ActiveSupport::Concern
     include Hydra::Works::MimeTypes
+    include CurationConcerns::SolrBehavior::Characterization
 
     def title_or_label
       return label if title.blank?

--- a/app/presenters/curation_concerns/characterization_behavior.rb
+++ b/app/presenters/curation_concerns/characterization_behavior.rb
@@ -1,0 +1,84 @@
+module CurationConcerns
+  module CharacterizationBehavior
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def characterization_terms
+        [
+          :byte_order, :compression, :height, :width, :height, :color_space,
+          :profile_name, :profile_version, :orientation, :color_map, :image_producer,
+          :capture_device, :scanning_software, :gps_timestamp, :latitude, :longitude,
+          :file_format, :file_title, :page_count, :duration, :sample_rate,
+          :format_label, :file_size, :filename, :well_formed, :last_modified,
+          :original_checksum, :mime_type
+        ]
+      end
+    end
+
+    included do
+      delegate(*characterization_terms, to: :solr_document)
+    end
+
+    def characterized?
+      !characterization_metadata.values.compact.empty?
+    end
+
+    def characterization_metadata
+      @characterization_metadata ||= build_characterization_metadata
+    end
+
+    # Override this if you want to inject additional characterization metadata
+    # Use a hash of key/value pairs where the value is an Array or String
+    # {
+    #   term1: ["value"],
+    #   term2: ["value1", "value2"],
+    #   term3: "a string"
+    # }
+    def additional_characterization_metadata
+      @additional_characterization_metadata ||= {}
+    end
+
+    def label_for_term(term)
+      term.to_s.titleize
+    end
+
+    # Returns an array of characterization values truncated to 250 characters limited
+    # to the maximum number of configured values.
+    # @param [Symbol] term found in the characterization_metadata hash
+    # @return [Array] of truncated values
+    def primary_characterization_values(term)
+      values = values_for(term)
+      values.slice!(CurationConcerns.config.fits_message_length, (values.length - CurationConcerns.config.fits_message_length))
+      truncate_all(values)
+    end
+
+    # Returns an array of characterization values truncated to 250 characters that are in
+    # excess of the maximum number of configured values.
+    # @param [Symbol] term found in the characterization_metadata hash
+    # @return [Array] of truncated values
+    def secondary_characterization_values(term)
+      values = values_for(term)
+      additional_values = values.slice(CurationConcerns.config.fits_message_length, values.length - CurationConcerns.config.fits_message_length)
+      return [] unless additional_values
+      truncate_all(additional_values)
+    end
+
+    private
+
+      def values_for(term)
+        Array.wrap(characterization_metadata[term])
+      end
+
+      def truncate_all(values)
+        values.map { |v| v.to_s.truncate(250) }
+      end
+
+      def build_characterization_metadata
+        self.class.characterization_terms.each do |term|
+          value = send(term)
+          additional_characterization_metadata[term.to_sym] = value unless value.blank?
+        end
+        additional_characterization_metadata
+      end
+  end
+end

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -2,6 +2,7 @@ module CurationConcerns
   class FileSetPresenter
     include ModelProxy
     include PresentsAttributes
+    include CurationConcerns::CharacterizationBehavior
     attr_accessor :solr_document, :current_ability, :request
 
     # @param [SolrDocument] solr_document

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -21,7 +21,8 @@ describe CurationConcerns::FileSetIndexer do
       resource_type: ['Book'],
       identifier: ['urn:isbn:1234567890'],
       based_near: ['Medina, Saudi Arabia'],
-      related_url: ['http://example.org/TheWork/'])
+      related_url: ['http://example.org/TheWork/']
+    )
   end
 
   let(:mock_file) do
@@ -32,7 +33,11 @@ describe CurationConcerns::FileSetIndexer do
       format_label: ['JPEG Image'],
       height: ['500'],
       width: ['600'],
-      file_size: ['12']
+      file_size: ['12'],
+      page_count: ['1'],
+      file_title: ['title'],
+      duration: ['0:1'],
+      sample_rate: ['sample rate']
     )
   end
 
@@ -81,6 +86,10 @@ describe CurationConcerns::FileSetIndexer do
       expect(subject['height_is']).to eq 500
       expect(subject['width_is']).to eq 600
       expect(subject[Solrizer.solr_name('digest', :symbol)]).to eq 'urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967'
+      expect(subject[Solrizer.solr_name('page_count')]).to eq ['1']
+      expect(subject[Solrizer.solr_name('file_title')]).to eq ['title']
+      expect(subject[Solrizer.solr_name('duration')]).to eq ['0:1']
+      expect(subject[Solrizer.solr_name('sample_rate')]).to eq ['sample rate']
     end
   end
 

--- a/spec/models/curation_concerns/file_set/characterization_spec.rb
+++ b/spec/models/curation_concerns/file_set/characterization_spec.rb
@@ -16,7 +16,7 @@ describe CurationConcerns::FileSet do
   describe '::characterization_terms' do
     subject { file_set.class.characterization_terms }
     it { is_expected.to contain_exactly(:format_label, :file_size, :height, :width, :filename, :well_formed,
-                                        :page_count, :file_title, :last_modified, :original_checksum, :mime_type) }
+                                        :page_count, :file_title, :last_modified, :original_checksum, :mime_type, :duration, :sample_rate) }
   end
 
   describe 'characterization_proxy' do

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -68,7 +68,8 @@ describe FileSet do
         { type: 'group', access: 'read', name: 'group2' },
         { type: 'person', access: 'read', name: 'user2' },
         { type: 'person', access: 'read', name: 'user3' },
-        { type: 'person', access: 'edit', name: 'user1' }]
+        { type: 'person', access: 'edit', name: 'user1' }
+      ]
     end
 
     it "has attached content" do
@@ -107,6 +108,8 @@ describe FileSet do
       expect(subject).to respond_to(:well_formed)
       expect(subject).to respond_to(:page_count)
       expect(subject).to respond_to(:file_title)
+      expect(subject).to respond_to(:duration)
+      expect(subject).to respond_to(:sample_rate)
       # :creator is characterization metadata?
       expect(subject).to respond_to(:creator)
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -64,4 +64,28 @@ describe SolrDocument do
       it { is_expected.to eq 'restricted' }
     end
   end
+
+  describe "#page_count" do
+    let(:attributes) { { page_count_tesim: ['1'] } }
+    subject { document.page_count }
+    it { is_expected.to eq ['1'] }
+  end
+
+  describe "#file_title" do
+    let(:attributes) { { file_title_tesim: ['title'] } }
+    subject { document.file_title }
+    it { is_expected.to eq ['title'] }
+  end
+
+  describe "#duration" do
+    let(:attributes) { { duration_tesim: ['time'] } }
+    subject { document.duration }
+    it { is_expected.to eq ['time'] }
+  end
+
+  describe "#sample_rate" do
+    let(:attributes) { { sample_rate_tesim: ['rate'] } }
+    subject { document.sample_rate }
+    it { is_expected.to eq ['rate'] }
+  end
 end

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 describe CurationConcerns::FileSetPresenter do
-  let(:solr_document) { SolrDocument.new("title_tesim" => ["foo bar"],
-                                         "human_readable_type_tesim" => ["File Set"],
-                                         "mime_type_ssi" => 'image/jpeg',
-                                         'label_tesim' => ['one', 'two'],
-                                         "has_model_ssim" => ["FileSet"]) }
+  let(:attributes) { { "title_tesim" => ["foo bar"],
+                       "human_readable_type_tesim" => ["File Set"],
+                       "mime_type_ssi" => 'image/jpeg',
+                       'label_tesim' => ['one', 'two'],
+                       "has_model_ssim" => ["FileSet"] } }
+  let(:solr_document) { SolrDocument.new(attributes) }
   let(:ability) { double }
   let(:presenter) { described_class.new(solr_document, ability) }
 
@@ -48,7 +49,10 @@ describe CurationConcerns::FileSetPresenter do
     let(:solr_properties) do
       ["date_uploaded", "depositor", "keyword", "title_or_label",
        "contributor", "creator", "title", "description", "publisher",
-       "subject", "language", "rights"]
+       "subject", "language", "rights", "format_label", "file_size",
+       "height", "width", "filename", "well_formed", "page_count",
+       "file_title", "last_modified", "original_checksum", "mime_type",
+       "duration", "sample_rate"]
     end
     it "delegates to the solr_document" do
       solr_properties.each do |property|
@@ -83,5 +87,126 @@ describe CurationConcerns::FileSetPresenter do
     let!(:download_link) { create(:download_link, itemId: presenter.id) }
     subject { presenter.single_use_links }
     it { is_expected.to include(CurationConcerns::SingleUseLinkPresenter) }
+  end
+
+  describe "characterization" do
+    describe "#characterization_metadata" do
+      subject { presenter.characterization_metadata }
+      it { is_expected.to be_kind_of(Hash) }
+
+      it "only has set attributes are in the metadata" do
+        expect(subject[:height]).to be_blank
+        expect(subject[:page_count]).to be_blank
+      end
+
+      context "when height is set" do
+        let(:attributes) { { height_is: '444' } }
+        it "only has set attributes are in the metadata" do
+          expect(subject[:height]).not_to be_blank
+          expect(subject[:page_count]).to be_blank
+        end
+      end
+    end
+
+    describe "#characterized?" do
+      subject { presenter }
+      context "when attributes are not set" do
+        let(:attributes) { {} }
+        it { is_expected.not_to be_characterized }
+      end
+
+      context "when height is set" do
+        let(:attributes) { { height_is: '444' } }
+        it { is_expected.to be_characterized }
+      end
+
+      context "when file_format is set" do
+        let(:attributes) { { file_format_tesim: ['format'] } }
+        it { is_expected.to be_characterized }
+      end
+    end
+
+    describe "#label_for_term" do
+      subject { presenter.label_for_term(:titleized_key) }
+      it { is_expected.to eq("Titleized Key") }
+    end
+
+    describe "with additional characterization metadata" do
+      let(:additional_metadata) do
+        {
+          foo: ["bar"],
+          fud: ["bars", "cars"]
+        }
+      end
+
+      before { allow(presenter).to receive(:additional_characterization_metadata).and_return(additional_metadata) }
+      subject { presenter }
+
+      specify do
+        expect(subject).to be_characterized
+        expect(subject.characterization_metadata[:foo]).to contain_exactly("bar")
+        expect(subject.characterization_metadata[:fud]).to contain_exactly("bars", "cars")
+      end
+    end
+
+    describe "characterization values" do
+      before { allow(presenter).to receive(:characterization_metadata).and_return(mock_metadata) }
+
+      context "with a limited set of short values" do
+        let(:mock_metadata) { { term: ["asdf", "qwer"] } }
+        describe "#primary_characterization_values" do
+          subject { presenter.primary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("asdf", "qwer") }
+        end
+        describe "#secondary_characterization_values" do
+          subject { presenter.secondary_characterization_values(:term) }
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context "with a value set exceeding the configured amount" do
+        let(:mock_metadata) { { term: ["1", "2", "3", "4", "5", "6", "7", "8"] } }
+        describe "#primary_characterization_values" do
+          subject { presenter.primary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("1", "2", "3", "4", "5") }
+        end
+        describe "#secondary_characterization_values" do
+          subject { presenter.secondary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("6", "7", "8") }
+        end
+      end
+
+      context "with values exceeding 250 characters" do
+        let(:mock_metadata) { { term: [("a" * 251), "2", "3", "4", "5", "6", ("b" * 251)] } }
+        describe "#primary_characterization_values" do
+          subject { presenter.primary_characterization_values(:term) }
+          it { is_expected.to contain_exactly(("a" * 247) + "...", "2", "3", "4", "5") }
+        end
+        describe "#secondary_characterization_values" do
+          subject { presenter.secondary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("6", (("b" * 247) + "...")) }
+        end
+      end
+
+      context "with a string as a value" do
+        let(:mock_metadata) { { term: "string" } }
+        describe "#primary_characterization_values" do
+          subject { presenter.primary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("string") }
+        end
+        describe "#secondary_characterization_values" do
+          subject { presenter.secondary_characterization_values(:term) }
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context "with an integer as a value" do
+        let(:mock_metadata) { { term: 1440 } }
+        describe "#primary_characterization_values" do
+          subject { presenter.primary_characterization_values(:term) }
+          it { is_expected.to contain_exactly("1440") }
+        end
+      end
+    end
   end
 end

--- a/spec/support/curation_concerns/factory_helpers.rb
+++ b/spec/support/curation_concerns/factory_helpers.rb
@@ -26,7 +26,9 @@ module CurationConcerns
                  file_title:        opts.fetch(:file_title, []),
                  last_modified:     opts.fetch(:last_modified, []),
                  original_checksum: opts.fetch(:original_checksum, []),
-                 digest:            opts.fetch(:digest, [])
+                 digest:            opts.fetch(:digest, []),
+                 duration:          opts.fetch(:duration, []),
+                 sample_rate:       opts.fetch(:sample_rate, [])
                 )
     end
   end


### PR DESCRIPTION
This is to fix https://github.com/projecthydra/sufia/issues/2431 in Sufia.

I put a PR into sufia (https://github.com/projecthydra/sufia/pull/2487) and was asked to move it to curation concerns.

This adds the characterization terms to the file set indexer, the solr document and more characterization terms to the fileset presenter.

@projecthydra/sufia-code-reviewers
