### PR TITLE
Allow thumbnail to be selected from the file manager

### DIFF
--- a/app/assets/javascripts/curation_concerns/file_manager.es6
+++ b/app/assets/javascripts/curation_concerns/file_manager.es6
@@ -1,6 +1,6 @@
 import SaveManager from 'curation_concerns/file_manager/save_manager'
 import SortManager from 'curation_concerns/file_manager/sorting'
-import {FileManagerMember} from 'curation_concerns/file_manager/member'
+import {InputTracker, FileManagerMember} from 'curation_concerns/file_manager/member'
 export default class FileManager {
   constructor() {
     this.save_manager = this.initialize_save_manager()
@@ -8,6 +8,7 @@ export default class FileManager {
     this.save_affix()
     this.member_tracking()
     this.sortable_placeholder()
+    this.resource_form()
   }
 
   initialize_save_manager() {
@@ -37,6 +38,22 @@ export default class FileManager {
     $("li[data-reorder-id]").each(function(index, element) {
       var manager_member = new FileManagerMember($(element), sm)
       $(element).data("file_manager_member", manager_member)
+    })
+  }
+
+  // Initialize a form that represents the parent resource as a whole.
+  // For the purpose of CC, this only comes with a thumbnail_id hidden field
+  // which is synchronized with the radio buttons on each member and then
+  // submitted with the SaveManager.
+  resource_form() {
+    let manager = new FileManagerMember($("#resource-form").parent(), this.save_manager)
+    $("#resource-form").parent().data("file_manager_member", manager)
+    // Track thumbnail ID hidden field
+    new InputTracker($("*[data-member-link=thumbnail_id]"), manager)
+    $("#sortable *[name=thumbnail_id]").change(function() {
+      let val = $("#sortable *[name=thumbnail_id]:checked").val()
+      $("*[data-member-link=thumbnail_id]").val(val)
+      $("*[data-member-link=thumbnail_id]").change()
     })
   }
 

--- a/app/assets/stylesheets/curation_concerns/modules/file_manager.scss
+++ b/app/assets/stylesheets/curation_concerns/modules/file_manager.scss
@@ -35,6 +35,13 @@
       .attributes {
         @extend .col-xs-12;
       }
+      .member_resource_options {
+        @extend .col-xs-12;
+        float: none;
+        input[type=radio] {
+          margin-left: 1px;
+        }
+      }
       .order-title {
         width: 85%;
       }
@@ -58,6 +65,13 @@
       }
       .attributes {
         @extend .col-xs-6;
+      }
+      .member_resource_options {
+        @extend .col-xs-12;
+        float: none;
+        input[type=radio] {
+          margin-left: 1px;
+        }
       }
       .order-title {
         width: 49%;

--- a/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -65,6 +65,10 @@ module CurationConcerns
       first(Solrizer.solr_name('hasRelatedMediaFragment', :symbol))
     end
 
+    def thumbnail_id
+      first(Solrizer.solr_name('thumbnail_id', :symbol))
+    end
+
     # Date created is indexed as a string. This allows users to enter values like: 'Circa 1840-1844'
     def date_created
       first(Solrizer.solr_name("date_created"))

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -38,7 +38,7 @@ module CurationConcerns
     # Metadata Methods
     delegate :title, :date_created, :date_modified, :date_uploaded, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
-             :lease_expiration_date, :rights, :source, to: :solr_document
+             :lease_expiration_date, :rights, :source, :thumbnail_id, to: :solr_document
 
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_set_presenters

--- a/app/services/curation_concerns/indexes_thumbnails.rb
+++ b/app/services/curation_concerns/indexes_thumbnails.rb
@@ -20,6 +20,7 @@ module CurationConcerns
     # @params [Hash] solr_document the solr document to add the field to
     def index_thumbnails(solr_document)
       solr_document[thumbnail_field] = thumbnail_path
+      solr_document[Solrizer.solr_name('thumbnail_id', :symbol)] = object.thumbnail_id
     end
 
     # Returns the value for the thumbnail path to put into the solr document

--- a/app/views/curation_concerns/base/_file_manager_actions.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_actions.html.erb
@@ -1,3 +1,4 @@
   <div class="actions form-horizontal panel panel-default">
     <%= button_tag "Save", class: "btn btn-primary disabled", data: { action: "save-actions" }%>
   </div>
+  <%= render "file_manager_resource_form" %>

--- a/app/views/curation_concerns/base/_file_manager_member.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_member.html.erb
@@ -1,31 +1,32 @@
 <li data-reorder-id='<%= node.id %>'>
-  <%= simple_form_for [main_app, node], remote: true, html: {'data-type': 'json'} do |f| %>
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <div class="order-title">
-          <%= f.input :title, as: :string, input_html: { name: "#{f.object.model_name.singular}[title][]", class: "title" }, value: node.to_s, label: false, hint: false %>
-        </div>
-        <div class="file-set-link pull-right">
-          <%= link_to contextual_path(node, @presenter), title: "Edit file" do %>
-            <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+      <%= simple_form_for [main_app, node], remote: true, html: {'data-type': 'json'} do |f| %>
+        <div class="panel-heading">
+          <div class="order-title">
+            <%= f.input :title, as: :string, input_html: { name: "#{f.object.model_name.singular}[title][]", class: "title" }, value: node.to_s, label: false, hint: false %>
+          </div>
+          <div class="file-set-link pull-right">
+            <%= link_to contextual_path(node, @presenter), title: "Edit file" do %>
+              <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+            <% end %>
+          </div>
+          <% if node.respond_to?(:page_title) %>
+            <div class="order-filename">
+              <em title="<%= node.page_title %>">(<%= truncate(node.page_title, length: 29) %>)</em>
+            </div>
           <% end %>
         </div>
-        <% if node.respond_to?(:page_title) %>
-          <div class="order-filename">
-            <em title="<%= node.page_title %>">(<%= truncate(node.page_title, length: 29) %>)</em>
+        <div class="panel-body">
+          <div class="text-center thumbnail">
+            <%= render "file_manager_thumbnail", node: node %>
           </div>
-        <% end %>
-      </div>
-      <div class="panel-body">
-        <div class="text-center thumbnail">
-          <%= render "file_manager_thumbnail", node: node %>
+          <div class="attributes">
+            <%= render "file_manager_attributes", node: node, f: f%>
+          </div>
+          <div class="spacer">
+          </div>
         </div>
-        <div class="attributes">
-          <%= render "file_manager_attributes", node: node, f: f%>
-        </div>
-        <div class="spacer">
-        </div>
-      </div>
+      <% end %>
+      <%= render "file_manager_member_resource_options", node: node %>
     </div>
-  <% end %>
 </li>

--- a/app/views/curation_concerns/base/_file_manager_member_resource_options.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_member_resource_options.html.erb
@@ -1,0 +1,6 @@
+      <div class="form-group radio_buttons member_resource_options">
+        <span class="radio">
+          <%= radio_button_tag "thumbnail_id", node.id, @presenter.thumbnail_id == node.id, id: "thumbnail_id_#{node.id}", class: "radio_buttons" %>
+          <%= label_tag "thumbnail_id_#{node.id}", "Thumbnail" %>
+        </span>
+      </div>

--- a/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
@@ -1,0 +1,5 @@
+<div class="resource-form-container">
+  <%= simple_form_for [main_app, @presenter], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
+    <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
+  <% end %>
+</div>

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -12,6 +12,7 @@ describe CurationConcerns::WorkIndexer do
     generic_work.works << child_work
     allow(CurationConcerns::ThumbnailPathService).to receive(:call).and_return("/downloads/#{file.id}?file=thumbnail")
     generic_work.representative_id = file.id
+    generic_work.thumbnail_id = file.id
   end
 
   subject { service.generate_solr_document }
@@ -20,6 +21,7 @@ describe CurationConcerns::WorkIndexer do
     expect(subject['member_ids_ssim']).to eq generic_work.member_ids
     expect(subject['generic_type_sim']).to eq ['Work']
     expect(subject.fetch('thumbnail_path_ss')).to eq "/downloads/#{file.id}?file=thumbnail"
+    expect(subject.fetch('thumbnail_id_ssim')).to eq file.id
   end
 
   context "when thumbnail_field is configured" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -16,6 +16,12 @@ describe SolrDocument do
     it { is_expected.to eq 'one' }
   end
 
+  describe "thumbnail_id" do
+    let(:attributes) { { Solrizer.solr_name('thumbnail_id', :symbol) => ['one'] } }
+    subject { document.thumbnail_id }
+    it { is_expected.to eq 'one' }
+  end
+
   describe "creator" do
     let(:attributes) { { Solrizer.solr_name('creator') => ['one', 'two'] } }
     subject { document.creator }

--- a/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
@@ -77,10 +77,22 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
   end
 
   it "renders a form for each member" do
-    expect(rendered).to have_selector("form", count: members.length)
+    expect(rendered).to have_selector("#sortable form", count: members.length)
   end
 
   it "renders an input for titles" do
     expect(rendered).to have_selector("input[name='file_set[title][]']")
+  end
+
+  it "renders a resource form for the entire resource" do
+    expect(rendered).to have_selector("form#resource-form")
+  end
+
+  it "renders a hidden field for the resource form thumbnail id" do
+    expect(rendered).to have_selector("#resource-form input[type=hidden][name='generic_work[thumbnail_id]']", visible: false)
+  end
+
+  it "renders a thumbnail field for each member" do
+    expect(rendered).to have_selector("input[name='thumbnail_id']", count: members.length)
   end
 end


### PR DESCRIPTION
There's now a thumbnail radio button which spans all the individual boxes in the file manager. It looks like this:

![screen shot 2016-08-19 at 2 10 37 pm](https://cloud.githubusercontent.com/assets/2806645/17824423/c0c20e28-6616-11e6-8f8a-d4c692aa6288.png)
