### PR TITLE
Clickable Whitespace around Image

### DIFF
--- a/app/assets/stylesheets/curation_concerns/_positioning.scss
+++ b/app/assets/stylesheets/curation_concerns/_positioning.scss
@@ -134,6 +134,7 @@ legend + .form-group {
   }
 }
 
-.img-responsive, figure {
-  display: inline-block;
+.representative-media {
+  display: block;
+  padding: 0.5em 0;
 }

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -1,12 +1,21 @@
 <% if CurationConcerns.config.display_media_download_link %>
-    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
-        <figure>
-            <%= image_tag "default.png", alt: "No preview available", class: "img-responsive" %>
-            <figcaption>Download the document</figcaption>
-        </figure>
-    <% end %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag "default.png",
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to main_app.download_path(file_set),
+                  target: "_new",
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.default_link') %>
+      <% end %>
+    </div>
 <% else %>
-    <figure>
-        <%= image_tag "default.png", alt: "No preview available", class: "img-responsive" %>
-    </figure>
+    <div>
+      <%= image_tag "default.png",
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
 <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -1,16 +1,21 @@
 <% if CurationConcerns.config.display_media_download_link %>
-    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized image" do %>
-        <figure>
-            <%= image_tag thumbnail_url(file_set),
-                          class: "img-responsive",
-                          alt: "Download the full-sized image of #{file_set.to_s}" %>
-            <figcaption>Download the full-sized image</figcaption>
-        </figure>
-    <% end %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to main_app.download_path(file_set),
+                  target: "_new",
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.image_link') %>
+      <% end %>
+    </div>
 <% else %>
-    <figure>
-        <%= image_tag thumbnail_url(file_set),
-                      class: "img-responsive",
-                      alt: "Thumbnail of #{file_set.to_s}" %>
-    </figure>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
 <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -1,16 +1,21 @@
 <% if CurationConcerns.config.display_media_download_link %>
-    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
-        <figure>
-            <%= image_tag thumbnail_url(file_set),
-                          class: "img-responsive",
-                          alt: "Download the document #{file_set.to_s}" %>
-            <figcaption>Download the document</figcaption>
-        </figure>
-    <% end %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to main_app.download_path(file_set),
+                  target: "_new",
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.office_link') %>
+      <% end %>
+    </div>
 <% else %>
-    <figure>
-        <%= image_tag thumbnail_url(file_set),
-                      class: "img-responsive",
-                      alt: "Thumbnail of #{file_set.to_s}" %>
-    </figure>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
 <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,16 +1,21 @@
 <% if CurationConcerns.config.display_media_download_link %>
-    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized PDF" do %>
-        <figure>
-            <%= image_tag thumbnail_url(file_set),
-                          class: "img-responsive",
-                          alt: "Download the full-sized PDF of #{file_set.to_s}" %>
-            <figcaption>Download the full-sized PDF</figcaption>
-        </figure>
-    <% end %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to main_app.download_path(file_set),
+                  target: "_new",
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.pdf_link') %>
+      <% end %>
+    </div>
 <% else %>
-    <figure>
-        <%= image_tag thumbnail_url(file_set),
-                      class: "img-responsive",
-                      alt: "Thumbnail of #{file_set.to_s}" %>
-    </figure>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
 <% end %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -16,6 +16,12 @@ en:
     show:
       related_files:
         heading: 'Members'
+      downloadable_content:
+        heading: 'Downloadable Content'
+        default_link: 'Download file'
+        image_link: 'Download image'
+        office_link: 'Download file'
+        pdf_link: 'Download PDF'
     search:
       form:
         q:

--- a/spec/views/curation_concerns/file_sets/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/show.html.erb_spec.rb
@@ -72,28 +72,28 @@ describe 'curation_concerns/file_sets/show.html.erb', type: :view do
         context 'with an image' do
           let(:mime_type) { 'image/tiff' }
           it 'renders the download link' do
-            expect(rendered).to have_link('Download the full-sized image')
+            expect(rendered).to have_link('Download image')
           end
         end
 
         context 'with a PDF' do
           let(:mime_type) { 'application/pdf' }
           it 'renders the download link' do
-            expect(rendered).to have_link('Download the full-sized PDF')
+            expect(rendered).to have_link('Download PDF')
           end
         end
 
         context 'with a word document' do
           let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
           it 'renders the download link' do
-            expect(rendered).to have_link('Download the document')
+            expect(rendered).to have_link('Download file')
           end
         end
 
         context 'with anything else' do
           let(:mime_type) { 'application/binary' }
           it 'renders the download link' do
-            expect(rendered).to have_link('Download the document')
+            expect(rendered).to have_link('Download file')
           end
         end
       end
@@ -107,28 +107,28 @@ describe 'curation_concerns/file_sets/show.html.erb', type: :view do
         context 'with an image' do
           let(:mime_type) { 'image/tiff' }
           it 'does not render the download link' do
-            expect(rendered).not_to have_link('Download the full-sized image')
+            expect(rendered).not_to have_link('Download image')
           end
         end
 
         context 'with a PDF' do
           let(:mime_type) { 'application/pdf' }
           it 'does not render the download link' do
-            expect(rendered).not_to have_link('Download the full-sized PDF')
+            expect(rendered).not_to have_link('Download PDF')
           end
         end
 
         context 'with a word document' do
           let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
           it 'does not render the download link' do
-            expect(rendered).not_to have_link('Download the document')
+            expect(rendered).not_to have_link('Download file')
           end
         end
 
         context 'with anything else' do
           let(:mime_type) { 'application/binary' }
           it 'does not render the download link' do
-            expect(rendered).not_to have_link('Download the document')
+            expect(rendered).not_to have_link('Download file')
           end
         end
       end


### PR DESCRIPTION
Fixes https://github.com/projecthydra/sufia/issues/2466

Made several changes for accessibility along with the removal of clickable whitespace. The image is no longer linked until we link to a viewer. Discussion from Sufia (see above) steered the PR to only link the text to download the image, document, PDF, etc.

Changes proposed in this pull request:
* Links only the download text
* Replaces figure and figcaption with div
* Linked thumbnail more presentational role and alt text does not convey meaningful information
* Removes title attribute because text is redundant
* Swaps img-responsive for representational-media
* Addresses accessibility
* Makes download link more visible by using Bootstrap's default button attributes

@projecthydra/sufia-code-reviewers

