### PR TITLE
Changing version revision to use the correct signature for CharacterizeJob

### DIFF
--- a/app/actors/curation_concerns/actors/file_actor.rb
+++ b/app/actors/curation_concerns/actors/file_actor.rb
@@ -34,9 +34,8 @@ module CurationConcerns
 
         CurationConcerns::VersioningService.create(repository_file, user)
 
-        # Retrieve a copy of the original file from the repository
-        working_file = WorkingDirectory.copy_repository_resource_to_working_directory(repository_file, file_set.id)
-        CharacterizeJob.perform_later(file_set, working_file)
+        # Characterize the original file from the repository
+        CharacterizeJob.perform_later(file_set, repository_file.id)
         true
       end
     end

--- a/spec/actors/curation_concerns/file_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_actor_spec.rb
@@ -30,8 +30,7 @@ describe CurationConcerns::Actors::FileActor do
 
     it 'reverts to a previous version of a file' do
       expect(CurationConcerns::VersioningService).to receive(:create).with(previous_version, user)
-      expect(CurationConcerns::WorkingDirectory).to receive(:copy_repository_resource_to_working_directory).with(previous_version, file_set.id).and_return(file_path)
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, file_path)
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, previous_version.id)
       actor.revert_to(revision_id)
     end
   end


### PR DESCRIPTION
Fixes https://github.com/projecthydra/sufia/issues/2404

The signature for characterization job changed a while back and this update was missed becuase the test is completely mocked.

I changed the mocking to the correct signature, but I am not certain that the test is really testing all that we want it to test.  Do people have ideas on how to better test the integration without writing an integration test?

@projecthydra/sufia-code-reviewers

