### PR TITLE
Unset file manager form callbacks after they run so they don't build up

### DIFF
--- a/app/assets/javascripts/curation_concerns/file_manager/member.es6
+++ b/app/assets/javascripts/curation_concerns/file_manager/member.es6
@@ -75,6 +75,12 @@ export class FileManagerMember {
         this.element.removeClass("success")
         this.element.removeClass("pending")
       })
+      // unset the callbacks after they've run so they don't build up
+      // and consume memory
+      deferred.always(function() {
+        form.off('ajax:success')
+        form.off('ajax:error')
+      })
       form.submit()
       return deferred
     } else {


### PR DESCRIPTION
pull request courtesy of hydra code club