### PR TITLE
Use the to_s method on the presenter

### DIFF
--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -19,7 +19,7 @@ module CurationConcerns
              :to_s, to: :solr_document
 
     # Metadata Methods
-    delegate :title_or_label, :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
+    delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
              :embargo_release_date, :lease_expiration_date, :rights, :date_created, to: :solr_document
 
     def size

--- a/app/views/collections/_search_form.html.erb
+++ b/app/views/collections/_search_form.html.erb
@@ -1,5 +1,5 @@
   <%= form_for presenter, method: :get, class: "well form-search" do |f| %>
-      <label class="sr-only"><%= t('curation_concerns.collections.search_form.label', title: presenter.title_or_label) %></label>
+      <label class="sr-only"><%= t('curation_concerns.collections.search_form.label', title: presenter.to_s) %></label>
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('curation_concerns.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
         <div class="input-group-btn">

--- a/spec/presenters/curation_concerns/collection_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/collection_presenter_spec.rb
@@ -17,8 +17,8 @@ describe CurationConcerns::CollectionPresenter do
   # Mock bytes so collection does not have to be saved.
   before { allow(collection).to receive(:bytes).and_return(0) }
 
-  describe '#title_or_label' do
-    subject { presenter.title_or_label }
+  describe '#to_s' do
+    subject { presenter.to_s }
     it { is_expected.to eq 'A clever title' }
   end
 


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

It's not necessary to delegate title_or_label since to_s is already
delegated. Reverts part of #943, which was causing a breaking change in
Sufia.