### PR TITLE
Refactor ingest workflow to use current working file

### DIFF
--- a/app/actors/curation_concerns/actors/file_actor.rb
+++ b/app/actors/curation_concerns/actors/file_actor.rb
@@ -20,9 +20,11 @@ module CurationConcerns
       # have made it to the repo
       # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file to save in the repository
       def ingest_file(file)
-        working_file = WorkingDirectory.copy_file_to_working_directory(file, file_set.id)
-        mime_type = file.respond_to?(:content_type) ? file.content_type : nil
-        IngestFileJob.perform_later(file_set, working_file, mime_type, user, relation)
+        IngestFileJob.perform_later(
+          file_set,
+          working_file(file),
+          user,
+          ingest_options(file))
         true
       end
 
@@ -38,6 +40,20 @@ module CurationConcerns
         CharacterizeJob.perform_later(file_set, repository_file.id)
         true
       end
+
+      private
+
+        def working_file(file)
+          path = file.path
+          return path if File.exist?(path)
+          CurationConcerns::WorkingDirectory.copy_file_to_working_directory(file, file_set.id)
+        end
+
+        def ingest_options(file, opts = {})
+          opts.merge!(mime_type: file.content_type) if file.respond_to?(:content_type)
+          opts.merge!(filename: file.original_filename) if file.respond_to?(:original_filename)
+          opts.merge!(relation: relation)
+        end
     end
   end
 end

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -3,13 +3,14 @@ class CharacterizeJob < ActiveJob::Base
 
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
-  def perform(file_set, file_id)
-    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
+  # @param [String, NilClass] filepath the cached file within the CurationConcerns.config.working_path
+  def perform(file_set, file_id, filepath = nil)
+    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
     raise LoadError, "#{file_set.class.characterization_proxy} was not found" unless file_set.characterization_proxy?
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.save!
     file_set.update_index
-    CreateDerivativesJob.perform_later(file_set, file_id)
+    CreateDerivativesJob.perform_later(file_set, file_id, filename)
   end
 end

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -3,9 +3,10 @@ class CreateDerivativesJob < ActiveJob::Base
 
   # @param [FileSet] file_set
   # @param [String] file_id identifier for a Hydra::PCDM::File
-  def perform(file_set, file_id)
+  # @param [String, NilClass] filepath the cached file within the CurationConcerns.config.working_path
+  def perform(file_set, file_id, filepath = nil)
     return if file_set.video? && !CurationConcerns.config.enable_ffmpeg
-    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id)
+    filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
 
     file_set.create_derivatives(filename)
 

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -2,36 +2,36 @@ class IngestFileJob < ActiveJob::Base
   queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
-  # @param [String] filename the cached file within the CurationConcerns.config.working_path
-  # @param [String,NilClass] mime_type
+  # @param [String] filepath the cached file within the CurationConcerns.config.working_path
   # @param [User] user
-  # @param [String] relation ('original_file')
-  def perform(file_set, filename, mime_type, user, relation = 'original_file')
-    local_file = File.open(filename, "rb")
-    # If mime-type is known, wrap in an IO decorator
-    # Otherwise allow Hydra::Works service to determine mime_type
-    if mime_type
-      local_file = Hydra::Derivatives::IoDecorator.new(local_file)
-      local_file.mime_type = mime_type
-      local_file.original_name = File.basename(filename)
-    end
+  # @option opts [String] mime_type
+  # @option opts [String] filename
+  # @option opts [String] relation, ex. :original_file
+  def perform(file_set, filepath, user, opts = {})
+    relation = opts.fetch(:relation, :original_file).to_sym
 
-    # Tell AddFileToFileSet service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
+    # Wrap in an IO decorator to attach passed-in options
+    local_file = Hydra::Derivatives::IoDecorator.new(File.open(filepath, "rb"))
+    local_file.mime_type = opts.fetch(:mime_type, nil)
+    local_file.original_name = opts.fetch(:filename, File.basename(filepath))
+
+    # Tell AddFileToFileSet service to skip versioning because versions will be minted by
+    # VersionCommitter when necessary during save_characterize_and_record_committer.
     Hydra::Works::AddFileToFileSet.call(file_set,
                                         local_file,
-                                        relation.to_sym,
+                                        relation,
                                         versioning: false)
 
     # Persist changes to the file_set
     file_set.save!
 
-    repository_file = file_set.send(relation.to_sym)
+    repository_file = file_set.send(relation)
 
     # Do post file ingest actions
     CurationConcerns::VersioningService.create(repository_file, user)
 
     # TODO: this is a problem, the file may not be available at this path on another machine.
     # It may be local, or it may be in s3
-    CharacterizeJob.perform_later(file_set, repository_file.id)
+    CharacterizeJob.perform_later(file_set, repository_file.id, filepath)
   end
 end

--- a/app/services/curation_concerns/working_directory.rb
+++ b/app/services/curation_concerns/working_directory.rb
@@ -1,10 +1,12 @@
 module CurationConcerns
-  module WorkingDirectory
+  class WorkingDirectory
     class << self
       # @param [String] repository_file_id identifier for Hydra::PCDM::File
       # @param [String] id the identifier of the FileSet
+      # @param [String, NilClass] filepath path to existing cached copy of the file
       # @return [String] path of the working file
-      def find_or_retrieve(repository_file_id, id)
+      def find_or_retrieve(repository_file_id, id, filepath = nil)
+        return filepath if filepath && File.exist?(filepath)
         repository_file = Hydra::PCDM::File.find(repository_file_id)
         working_path = full_filename(id, repository_file.original_name)
         if File.exist?(working_path)

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sprockets-es6'
   spec.add_dependency 'kaminari_route_prefix', '~> 0.0.1'
   spec.add_dependency 'active_attr'
-  spec.add_dependency 'hydra-works', '>= 0.12.0'
+  spec.add_dependency 'hydra-works', '>= 0.14.0'
   spec.add_dependency 'active_fedora-noid', '~> 2.0.0.beta1'
   spec.add_dependency 'qa', '~> 0.5'
   spec.add_dependency 'redlock', '~> 0.1.2'

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -25,7 +25,7 @@ describe CharacterizeJob do
       expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
       expect(file).to receive(:save!)
       expect(file_set).to receive(:update_index)
-      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id)
+      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
       described_class.perform_now(file_set, file.id)
     end
   end

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -20,28 +20,33 @@ describe IngestFileJob do
       Object.send(:remove_const, :FileSetWithExtras)
     end
     it 'uses the provided relationship' do
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String)
-      described_class.perform_now(file_set, filename, 'image/png', 'bob', 'remastered')
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String, filename)
+      described_class.perform_now(file_set, filename, user, mime_type: 'image/png', relation: 'remastered')
       expect(file_set.reload.remastered.mime_type).to eq 'image/png'
     end
   end
 
   context 'when given a mime_type' do
     it 'uses the provided mime_type' do
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String)
-      described_class.perform_now(file_set, filename, 'image/png', 'bob')
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String, filename)
+      described_class.perform_now(file_set, filename, user, mime_type: 'image/png')
       expect(file_set.reload.original_file.mime_type).to eq 'image/png'
     end
   end
 
   context 'when not given a mime_type' do
-    it 'does not decorate File when not given mime_type' do
-      # Mocking CC Versioning here as it will be the versioning machinery called by the job.
-      # The parameter versioning: false instructs the machinery in Hydra::Works NOT to do versioning. So it can be handled later on.
-      allow(CurationConcerns::VersioningService).to receive(:create)
-      expect(Hydra::Works::AddFileToFileSet).to receive(:call).with(file_set, instance_of(::File), :original_file, versioning: false).and_call_original
-      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String)
-      described_class.perform_now(file_set, filename, nil, 'bob')
+    before { allow(CurationConcerns::VersioningService).to receive(:create) }
+    it 'passes a decorated instance of the file with a nil mime_type' do
+      # The parameter versioning: false instructs the machinery in Hydra::Works NOT to do versioning
+      # so it can be handled later on.
+      expect(Hydra::Works::AddFileToFileSet).to receive(:call).with(
+        file_set,
+        instance_of(Hydra::Derivatives::IoDecorator),
+        :original_file,
+        versioning: false
+      ).and_call_original
+      expect(CharacterizeJob).to receive(:perform_later).with(file_set, String, filename)
+      described_class.perform_now(file_set, filename, user)
     end
   end
 
@@ -53,8 +58,8 @@ describe IngestFileJob do
 
     before do
       allow(Hydra::Works::CharacterizationService).to receive(:run).with(any_args)
-      described_class.perform_now(file_set, file1, 'image/png', user.user_key)
-      described_class.perform_now(file_set, file2, 'text/plain', user2.user_key)
+      described_class.perform_now(file_set, file1, user.user_key, mime_type: 'image/png')
+      described_class.perform_now(file_set, file2, user2.user_key, mime_type: 'text/plain')
     end
 
     it 'has two versions' do


### PR DESCRIPTION
Fixes projecthydra/sufia#2553

If the current working file used by the initial ingest is already available locally, it should pass that file to successive jobs. Each subsequent job
can verify the file still exists locally and continue to use it; otherwise, it will download a new local working copy.

Modifications are also made to IngestFileJob so that a Hydra::Derivatives::IoDecorator is always passed to Hydra::Works::AddFileToFileSet with a value for `original_name` and a mime type, if it is provided.


@projecthydra/sufia-code-reviewers

