### PR TITLE
Indexing for related file properties

### DIFF
--- a/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -66,7 +66,7 @@ module CurationConcerns
     end
 
     def thumbnail_id
-      first(Solrizer.solr_name('thumbnail_id', :symbol))
+      first(Solrizer.solr_name('hasRelatedImage', :symbol))
     end
 
     # Date created is indexed as a string. This allows users to enter values like: 'Circa 1840-1844'

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -38,7 +38,8 @@ module CurationConcerns
     # Metadata Methods
     delegate :title, :date_created, :date_modified, :date_uploaded, :description,
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
-             :lease_expiration_date, :rights, :source, :thumbnail_id, to: :solr_document
+             :lease_expiration_date, :rights, :source, :thumbnail_id, :representative_id,
+             to: :solr_document
 
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_set_presenters

--- a/app/services/curation_concerns/indexes_thumbnails.rb
+++ b/app/services/curation_concerns/indexes_thumbnails.rb
@@ -20,7 +20,6 @@ module CurationConcerns
     # @params [Hash] solr_document the solr document to add the field to
     def index_thumbnails(solr_document)
       solr_document[thumbnail_field] = thumbnail_path
-      solr_document[Solrizer.solr_name('thumbnail_id', :symbol)] = object.thumbnail_id
     end
 
     # Returns the value for the thumbnail path to put into the solr document

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -59,6 +59,7 @@ describe CurationConcerns::FileSetIndexer do
 
     it 'has fields' do
       expect(subject[Solrizer.solr_name('hasRelatedMediaFragment', :symbol)]).to eq 'foo123'
+      expect(subject[Solrizer.solr_name('hasRelatedImage', :symbol)]).to eq 'foo123'
       expect(subject[Solrizer.solr_name('part_of')]).to be_nil
       expect(subject[Solrizer.solr_name('date_uploaded')]).to be_nil
       expect(subject[Solrizer.solr_name('date_modified')]).to be_nil

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -23,6 +23,7 @@ describe CurationConcerns::WorkIndexer do
       expect(solr_document['generic_type_sim']).to eq ['Work']
       expect(solr_document.fetch('thumbnail_path_ss')).to eq "/downloads/#{file.id}?file=thumbnail"
       expect(subject.fetch('hasRelatedImage_ssim').first).to eq file.id
+      expect(subject.fetch('hasRelatedMediaFragment_ssim').first).to eq file.id
     end
 
     context "when thumbnail_field is configured" do

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -22,7 +22,7 @@ describe CurationConcerns::WorkIndexer do
       expect(solr_document['member_ids_ssim']).to eq work.member_ids
       expect(solr_document['generic_type_sim']).to eq ['Work']
       expect(solr_document.fetch('thumbnail_path_ss')).to eq "/downloads/#{file.id}?file=thumbnail"
-      expect(subject.fetch('thumbnail_id_ssim')).to eq file.id
+      expect(subject.fetch('hasRelatedImage_ssim').first).to eq file.id
     end
 
     context "when thumbnail_field is configured" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -17,7 +17,7 @@ describe SolrDocument do
   end
 
   describe "thumbnail_id" do
-    let(:attributes) { { Solrizer.solr_name('thumbnail_id', :symbol) => ['one'] } }
+    let(:attributes) { { Solrizer.solr_name('hasRelatedImage', :symbol) => ['one'] } }
     subject { document.thumbnail_id }
     it { is_expected.to eq 'one' }
   end


### PR DESCRIPTION
- Deduplicate thumbnail_id (remove new solr field `thumbnail_id` in favor of previously-in-use `hasRelatedImage`)
- Add representative_id to work indexer (using already-named `hasRelatedMediaFragment` field)

Pairing these commits in one PR because the fields were set up symmetrically and are functionally similar; also both are related to file manager work.