### PR TITLE
Add renderer for external links attributes.

### DIFF
--- a/app/renderers/curation_concerns/renderers/external_link_attribute_renderer.rb
+++ b/app/renderers/curation_concerns/renderers/external_link_attribute_renderer.rb
@@ -1,0 +1,13 @@
+module CurationConcerns
+  module Renderers
+    class ExternalLinkAttributeRenderer < AttributeRenderer
+      private
+
+        def li_value(value)
+          auto_link(value) do |link|
+            "<span class='glyphicon glyphicon-new-window'></span>&nbsp;#{link}"
+          end
+        end
+    end
+  end
+end

--- a/spec/renderers/curation_concerns/renderers/external_link_attribute_renderer_spec.rb
+++ b/spec/renderers/curation_concerns/renderers/external_link_attribute_renderer_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe CurationConcerns::Renderers::ExternalLinkAttributeRenderer do
+  let(:field) { :name }
+  let(:renderer) { described_class.new(field, ['http://example.com']) }
+
+  describe "#attribute_to_html" do
+    subject { Nokogiri::HTML(renderer.render) }
+    let(:expected) { Nokogiri::HTML(tr_content) }
+
+    let(:tr_content) {
+      "<tr><th>Name</th>\n" \
+       "<td><ul class='tabular'>" \
+       "<li class=\"attribute name\">"\
+       "<a href=\"http://example.com\">"\
+       "<span class='glyphicon glyphicon-new-window'></span>&nbsp;"\
+       "http://example.com</a></li>\n" \
+       "</ul></td></tr>"
+    }
+    it { expect(subject).to be_equivalent_to(expected) }
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/projecthydra/sufia/issues/2472

Adds a renderer for external link attributes which includes external icon. 

@projecthydra/sufia-code-reviewers

