### PR TITLE
Re-index collections if their files have been characterized.

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -11,6 +11,7 @@ class CharacterizeJob < ActiveJob::Base
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.save!
     file_set.update_index
+    file_set.parent.in_collections.each(&:update_index) if file_set.parent
     CreateDerivativesJob.perform_later(file_set, file_id, filename)
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -36,4 +36,21 @@ describe CharacterizeJob do
       expect { described_class.perform_now(file_set, file.id) }.to raise_error(LoadError, 'original_file was not found')
     end
   end
+
+  context "when the file set's work is in a collection" do
+    let(:work)       { build(:generic_work) }
+    let(:collection) { build(:collection) }
+    before do
+      allow(file_set).to receive(:parent).and_return(work)
+      allow(work).to receive(:in_collections).and_return([collection])
+      allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
+      allow(file).to receive(:save!)
+      allow(file_set).to receive(:update_index)
+      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+    end
+    it "reindexes the collection" do
+      expect(collection).to receive(:update_index)
+      described_class.perform_now(file_set, file.id)
+    end
+  end
 end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Fixes projecthydra/sufia#2410

When works are added to a collection during the work's creation process, things like the collection's size need to be updated. Since this is determined using the characterization metadata, we need to update the collection's metadata when the file's characterization metadata is created or updated.