### PR TITLE
MemberSearchBuilder does not need collection from the scope

### DIFF
--- a/app/search_builders/curation_concerns/member_search_builder.rb
+++ b/app/search_builders/curation_concerns/member_search_builder.rb
@@ -6,12 +6,16 @@ module CurationConcerns
     # Defines which search_params_logic should be used when searching for Collection members
     self.default_processor_chain += [:include_collection_ids]
 
-    delegate :collection, to: :scope
-
     # include filters into the query to only include the collection memebers
     def include_collection_ids(solr_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "{!join from=#{from_field} to=id}id:#{collection.id}"
+      solr_parameters[:fq] << "{!join from=#{from_field} to=id}id:#{collection_id}"
     end
+
+    protected
+
+      def collection_id
+        blacklight_params.fetch('id')
+      end
   end
 end


### PR DESCRIPTION
The collection id is already passed to the search builder as parameters.
This loosens the coupling between the search builder and the controller.