### PR TITLE
Make CollectionSearchBuilder access-level aware

### DIFF
--- a/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
@@ -13,6 +13,9 @@ module CurationConcerns
 
       # This is needed as of BL 3.7
       copy_blacklight_config_from(::CatalogController)
+      configure_blacklight do |config|
+        config.search_builder_class = CurationConcerns::CollectionSearchBuilder
+      end
 
       # Catch permission errors
       rescue_from Hydra::AccessDenied, CanCan::AccessDenied do |exception|
@@ -203,8 +206,8 @@ module CurationConcerns
       alias collection_member_search_builder member_search_builder
       deprecation_deprecate collection_member_search_builder: "use member_search_builder instead"
 
-      def list_search_builder
-        list_search_builder_class.new(self)
+      def list_search_builder(access_level = nil)
+        list_search_builder_class.new(self, access_level)
       end
 
       alias collections_search_builder list_search_builder

--- a/app/controllers/concerns/curation_concerns/selects_collections.rb
+++ b/app/controllers/concerns/curation_concerns/selects_collections.rb
@@ -9,6 +9,8 @@ module CurationConcerns::SelectsCollections
     end
   end
 
+  # @return [Hash{Symbol => Array[Symbol]}] bottom-up map of "what you need" to "what qualifies"
+  # @note i.e., requiring :read access is satisfied by either :read or :edit access
   def access_levels
     { read: [:read, :edit], edit: [:edit] }
   end
@@ -59,8 +61,8 @@ module CurationConcerns::SelectsCollections
   end
 
   def collections_search_builder(access_level = nil)
-    collections_search_builder_class.new(self).tap do |builder|
-      builder.discovery_perms = access_levels[access_level] if access_level
+    collections_search_builder_class.new(self, nil).tap do |builder|
+      builder.discovery_permissions = access_levels[access_level] if access_level
     end
   end
 end

--- a/app/controllers/concerns/curation_concerns/selects_collections.rb
+++ b/app/controllers/concerns/curation_concerns/selects_collections.rb
@@ -61,8 +61,6 @@ module CurationConcerns::SelectsCollections
   end
 
   def collections_search_builder(access_level = nil)
-    collections_search_builder_class.new(self, nil).tap do |builder|
-      builder.discovery_permissions = access_levels[access_level] if access_level
-    end
+    collections_search_builder_class.new(self, access_levels[access_level])
   end
 end

--- a/app/search_builders/curation_concerns/README.md
+++ b/app/search_builders/curation_concerns/README.md
@@ -1,0 +1,69 @@
+# Search Builders
+
+Building searches is core to any Blacklight app, and CurationConcerns is no exception.  
+This directory contains our Search Builders, so named because the design followed a builder pattern, meaning
+that when invoked to set values, methods return the object itself, so that invocations can be chained, like:
+
+```ruby
+builder = Blacklight::SearchBuilder.new(processor_chain, scope)
+            .rows(20)
+            .page(3)
+            .with(q: 'Abraham Lincoln')
+```
+
+However, at this level, many if not most of the additional methods do not follow this pattern.  
+Refer to the `Blacklight::SearchBuilder` class if you want to be certain.  That leads to the next topic...
+
+## Ancestry
+
+Most of the SearchBuilders have `::SearchBuilder` as a parent or ancestor.  `::SearchBuilder` does not exist in any repo: it is generated
+by Blacklight and modified by CurationConcerns.  Others descend from `Blacklight::SearchBuilder`, or various other relatives.  
+
+### ::SearchBuilder
+
+The generated parent class `SearchBuilder` descends from `Blacklight::SearchBuilder`.
+As modified by CurationConcerns' installer, it includes additional modules and overrides.  So if your SearchBuilder has `::SearchBuilder` as a parent class, you are getting:
+- [Blacklight::SearchBuilder](https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/search_builder.rb) grandparent class
+- [Blacklight::Solr::SearchBuilderBehavior](https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/solr/search_builder_behavior.rb) associated methods
+- [Hydra::AccessControlsEnforcement](https://github.com/projecthydra/hydra-head/blob/master/hydra-access-controls/lib/hydra/access_controls_enforcement.rb) module
+  -  [Blacklight::AccessControls::Enforcement](https://github.com/projectblacklight/blacklight-access_controls/blob/master/lib/blacklight/access_controls/enforcement.rb) ancestor of `Hydra::AccessControlsEnforcement`
+- [CurationConcerns::SearchFilters](https://github.com/projecthydra/curation_concerns/blob/master/app/search_builders/curation_concerns/search_filters.rb)  module that itself includes:
+  - [BlacklightAdvancedSearch::AdvancedSearchBuilder](https://github.com/projectblacklight/blacklight_advanced_search/blob/master/lib/blacklight_advanced_search/advanced_search_builder.rb) more magic for compound Boolean queries
+  - [CurationConcerns::FilterByType](https://github.com/projecthydra/curation_concerns/blob/master/app/search_builders/curation_concerns/filter_by_type.rb) Collection vs. Work filtering, specifically the `filter_models` method
+
+This is not a comprehensive list, but it is sufficient to trace some of the complexity of interaction between various layers.
+
+## Development: AKA Doing Something Useful
+
+Note, the `default_processor_chain` defined by `Blacklight::Solr::SearchBuilderBehavior` provides a way to extend functionality, but also many possible points of override (namely method names).  When you need to do something novel and additional, adding to the chain is completely reasonable.  For example:
+
+```ruby
+module MySearchBuilder
+  extend ActiveSupport::Concern
+
+  included do
+    self.default_processor_chain += [:special_filter]
+  end
+
+  def special_filter(solr_parameters)
+    solr_parameters[:fq] << "{!field f=some_field_ssim}#{...}"
+  end
+end
+```
+
+But to the extent that you are overriding (or undoing) something already done, `CurationConcerns::FileSetSearchBuilder` is a better example:
+
+```ruby
+module CurationConcerns
+  class FileSetSearchBuilder < ::SearchBuilder
+    include CurationConcerns::SingleResult
+
+    # This overrides the filter_models in FilterByType
+    def filter_models(solr_parameters)
+      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::FileSet.to_class_uri)
+    end
+  end
+end
+```
+
+There is no point having the other `filter_models` methods apply `:fq`s that we then try to undo or overwrite.  In general, directly overwriting the whole `default_processor_chain` or solr parameters like `:fq` is less flexible than appending constraints sufficient for your use case.  In particular, you might find that you have overwritten components that implement access controls, thereby making your SearchBuilder less useful and less secure.  When in doubt, examine the actual solr queries produced.

--- a/app/search_builders/curation_concerns/collection_search_builder.rb
+++ b/app/search_builders/curation_concerns/collection_search_builder.rb
@@ -30,18 +30,8 @@ module CurationConcerns
       { read: [:read, :edit], edit: [:edit] }
     end
 
-    ## Overrides
-
-    # unprotect lib/blacklight/access_controls/enforcement.rb methods
-    # Remove these when https://github.com/projectblacklight/blacklight-access_controls/pull/23 is merged/released/required
-    def discovery_permissions
-      super
-    end
-
-    def discovery_permissions=(*args)
-      super
-    end
-
+    # @!group Overrides
+    #
     # This overrides the filter_models in FilterByType
     def filter_models(solr_parameters)
       solr_parameters[:fq] ||= []

--- a/app/search_builders/curation_concerns/collection_search_builder.rb
+++ b/app/search_builders/curation_concerns/collection_search_builder.rb
@@ -1,9 +1,6 @@
 module CurationConcerns
   # Our parent class is the generated SearchBuilder descending from Blacklight::SearchBuilder
-  # It includes Blacklight::Solr::SearchBuilderBehavior, Hydra::AccessControlsEnforcement, CurationConcerns::SearchFilters
-  # @see https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/search_builder.rb Blacklight::SearchBuilder parent
-  # @see https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/solr/search_builder_behavior.rb Blacklight::Solr::SearchBuilderBehavior
-  # @note the default_processor_chain defined by Blacklight::Solr::SearchBuilderBehavior provides many possible points of override
+  # @see https://github.com/projecthydra/curation_concerns/blob/master/app/search_builders/curation_concerns/README.md SearchBuilders README
   #
   class CollectionSearchBuilder < ::SearchBuilder
     include FilterByType

--- a/app/search_builders/curation_concerns/collection_search_builder.rb
+++ b/app/search_builders/curation_concerns/collection_search_builder.rb
@@ -1,14 +1,17 @@
 module CurationConcerns
-  # Our parent class is the generated SearchBuilder descending from Blacklight::SearchBuilder
+  # Our parent class is the generated SearchBuilder descending from Blacklight::SearchBuilder.
+  # Defines search_params_logic used when searching for Collections.
   # @see https://github.com/projecthydra/curation_concerns/blob/master/app/search_builders/curation_concerns/README.md SearchBuilders README
   #
   class CollectionSearchBuilder < ::SearchBuilder
-    include FilterByType
-    # Defines which search_params_logic should be used when searching for Collections
-    def initialize(context, access)
-      @access = access_levels[access]
+    # @param [#blacklight_config, #current_ability] scope the object that has access to #blacklight_config
+    #   From a controller, scope would be `self`.  This argument passed to ::SearchBuilder.new()
+    # @param [Symbol] permissions defining breadth of search, e.g. :edit, :read
+    # @note permissions will otherwise be defaulted by inherited #discovery_permissions
+    def initialize(scope, access = nil)
       @rows = 100
-      super(context)
+      @discovery_permissions ||= access_levels[access] if access
+      super(scope)
     end
 
     # @return [String] class URI of the model, as indexed in Solr has_model_ssim field
@@ -18,7 +21,7 @@ module CurationConcerns
 
     # @return [String] Solr field name indicating default sort order
     def sort_field
-      Solrizer.solr_name('title', :sortable)
+      'title_si'
     end
 
     # @return [Hash{Symbol => Array[Symbol]}] bottom-up map of "what you need" to "what qualifies"

--- a/app/search_builders/curation_concerns/collection_search_builder.rb
+++ b/app/search_builders/curation_concerns/collection_search_builder.rb
@@ -1,35 +1,58 @@
 module CurationConcerns
+  # Our parent class is the generated SearchBuilder descending from Blacklight::SearchBuilder
+  # It includes Blacklight::Solr::SearchBuilderBehavior, Hydra::AccessControlsEnforcement, CurationConcerns::SearchFilters
+  # @see https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/search_builder.rb Blacklight::SearchBuilder parent
+  # @see https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/solr/search_builder_behavior.rb Blacklight::Solr::SearchBuilderBehavior
+  # @note the default_processor_chain defined by Blacklight::Solr::SearchBuilderBehavior provides many possible points of override
+  #
   class CollectionSearchBuilder < ::SearchBuilder
     include FilterByType
     # Defines which search_params_logic should be used when searching for Collections
-    self.default_processor_chain = [:default_solr_parameters, :add_query_to_solr,
-                                    :add_access_controls_to_solr_params, :filter_models,
-                                    :some_rows, :sort_by_title]
-
-    def some_rows(solr_parameters)
-      solr_parameters[:rows] = '100'
+    def initialize(context, access)
+      @access = access_levels[access]
+      @rows = 100
+      super(context)
     end
 
-    # This overrides FilterByType and ensures we only match on collections.
-    def only_collections?
-      true
+    # @return [String] class URI of the model, as indexed in Solr has_model_ssim field
+    def model_class_uri
+      ::Collection.to_class_uri
+    end
+
+    # @return [String] Solr field name indicating default sort order
+    def sort_field
+      Solrizer.solr_name('title', :sortable)
+    end
+
+    # @return [Hash{Symbol => Array[Symbol]}] bottom-up map of "what you need" to "what qualifies"
+    # @note i.e., requiring :read access is satisfied by either :read or :edit access
+    def access_levels
+      { read: [:read, :edit], edit: [:edit] }
+    end
+
+    ## Overrides
+
+    # unprotect lib/blacklight/access_controls/enforcement.rb methods
+    # Remove these when https://github.com/projectblacklight/blacklight-access_controls/pull/23 is merged/released/required
+    def discovery_permissions
+      super
+    end
+
+    def discovery_permissions=(*args)
+      super
+    end
+
+    # This overrides the filter_models in FilterByType
+    def filter_models(solr_parameters)
+      solr_parameters[:fq] ||= []
+      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: model_class_uri)
     end
 
     # Sort results by title if no query was supplied.
     # This overrides the default 'relevance' sort.
-    def sort_by_title(solr_parameters)
+    def add_sorting_to_solr(solr_parameters)
       return if solr_parameters[:q]
       solr_parameters[:sort] ||= "#{sort_field} asc"
-    end
-
-    attr_writer :discovery_perms
-
-    def discovery_permissions
-      @discovery_perms || super
-    end
-
-    def sort_field
-      Solrizer.solr_name('title', :sortable)
     end
   end
 end

--- a/app/search_builders/curation_concerns/collection_search_builder.rb
+++ b/app/search_builders/curation_concerns/collection_search_builder.rb
@@ -8,15 +8,19 @@ module CurationConcerns
     #   From a controller, scope would be `self`.  This argument passed to ::SearchBuilder.new()
     # @param [Symbol] permissions defining breadth of search, e.g. :edit, :read
     # @note permissions will otherwise be defaulted by inherited #discovery_permissions
+    # @see @discovery_permissions
+    # @see @discovery_permissions
     def initialize(scope, access = nil)
       @rows = 100
       @discovery_permissions ||= access_levels[access] if access
       super(scope)
     end
 
-    # @return [String] class URI of the model, as indexed in Solr has_model_ssim field
-    def model_class_uri
-      ::Collection.to_class_uri
+    # @!group Overrides
+    #
+    # @return [Class] ActiveFedora model(s) indexed in Solr has_model_ssim field
+    def models
+      [::Collection]
     end
 
     # @return [String] Solr field name indicating default sort order
@@ -24,25 +28,14 @@ module CurationConcerns
       'title_si'
     end
 
-    # @return [Hash{Symbol => Array[Symbol]}] bottom-up map of "what you need" to "what qualifies"
-    # @note i.e., requiring :read access is satisfied by either :read or :edit access
-    def access_levels
-      { read: [:read, :edit], edit: [:edit] }
-    end
+    # @!endgroup
 
-    # @!group Overrides
-    #
-    # This overrides the filter_models in FilterByType
-    def filter_models(solr_parameters)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: model_class_uri)
-    end
+    private
 
-    # Sort results by title if no query was supplied.
-    # This overrides the default 'relevance' sort.
-    def add_sorting_to_solr(solr_parameters)
-      return if solr_parameters[:q]
-      solr_parameters[:sort] ||= "#{sort_field} asc"
-    end
+      # @return [Hash{Symbol => Array[Symbol]}] bottom-up map of "what you need" to "what qualifies"
+      # @note i.e., requiring :read access is satisfied by either :read or :edit access
+      def access_levels
+        { read: [:read, :edit], edit: [:edit] }
+      end
   end
 end

--- a/app/services/curation_concerns/collections_service.rb
+++ b/app/services/curation_concerns/collections_service.rb
@@ -20,9 +20,7 @@ module CurationConcerns
     private
 
       def list_search_builder(access)
-        list_search_builder_class.new(context).tap do |builder|
-          builder.discovery_perms = [access]
-        end
+        list_search_builder_class.new(context, access)
       end
   end
 end

--- a/app/services/curation_concerns/embargo_service.rb
+++ b/app/services/curation_concerns/embargo_service.rb
@@ -30,19 +30,6 @@ module CurationConcerns
         def presenter_class
           CurationConcerns::EmbargoPresenter
         end
-
-        def presenters(builder)
-          response = repository.search(builder)
-          response.documents.map { |d| presenter_class.new(d) }
-        end
-
-        def repository
-          config.repository
-        end
-
-        def config
-          @config ||= ::CatalogController.new
-        end
     end
   end
 end

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'hydra-head', '>= 10.0.0', '< 11'
+  spec.add_dependency 'hydra-head', '>= 10.3.0', '< 11'
   spec.add_dependency 'active-fedora', '>= 10.3.0.rc1'
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'breadcrumbs_on_rails', '>= 3.0.1', '< 4'

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rdf', '>= 1.99'
   spec.add_dependency 'rdf-vocab', '>= 0.8'
   spec.add_dependency 'awesome_nested_set', '~> 3.0'
-  spec.add_dependency 'browse-everything', '~> 0.10'
+  spec.add_dependency 'browse-everything', '~> 0.10', '>= 0.10.5'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'power_converter', '~> 0.1', '>= 0.1.2'
   spec.add_dependency 'dry-validation', '~> 0.9'

--- a/spec/controllers/selects_collections_controller_spec.rb
+++ b/spec/controllers/selects_collections_controller_spec.rb
@@ -11,11 +11,9 @@ end
 describe SelectsCollectionsController, type: :controller do
   describe "#find_collections" do
     it "uses the search builder" do
-      expect(subject.collections_search_builder_class.default_processor_chain).to eq [
-        :default_solr_parameters, :add_query_to_solr,
-        :add_access_controls_to_solr_params, :filter_models,
-        :some_rows, :sort_by_title]
-      expect(CurationConcerns::CollectionSearchBuilder).to receive(:new).with(subject).and_call_original
+      expect(subject.collections_search_builder_class.default_processor_chain)
+        .to include(:default_solr_parameters, :add_query_to_solr, :add_access_controls_to_solr_params)
+      expect(CurationConcerns::CollectionSearchBuilder).to receive(:new).with(subject, nil).and_call_original
       subject.find_collections
     end
   end

--- a/spec/search_builders/curation_concerns/collection_search_builder_spec.rb
+++ b/spec/search_builders/curation_concerns/collection_search_builder_spec.rb
@@ -1,15 +1,75 @@
 require 'spec_helper'
 
 describe CurationConcerns::CollectionSearchBuilder do
-  let(:context) { double('context') }
+  let(:context) { double('context', blacklight_config: blacklight_config) }
   let(:solr_params) { { fq: [] } }
+  let(:blacklight_config) { CatalogController.blacklight_config.deep_copy }
 
-  subject { described_class.new(context, :read) }
-  describe '#filter_models' do
-    before { subject.filter_models(solr_params) }
+  RSpec.shared_examples 'common SearchBuilder' do
+    it { should be_a SearchBuilder }
 
-    it 'adds Collection to :fq' do
-      expect(solr_params[:fq].first).to include('{!field f=has_model_ssim}Collection')
+    describe '#filter_models' do
+      it 'adds Collection to :fq' do
+        subject.filter_models(solr_params)
+        expect(solr_params[:fq].first).to include('{!field f=has_model_ssim}Collection')
+      end
+    end
+
+    describe '#sort' do
+      it 'returns default sort' do
+        expect(subject.sort).to eq 'score desc, date_uploaded_dtsi desc'
+      end
+    end
+
+    describe '#processor_chain' do
+      it 'includes methods we override' do
+        expect(subject.processor_chain).to include(:add_sorting_to_solr, :filter_models)
+      end
+    end
+
+    describe '#add_sorting_to_solr' do
+      it 'without query, applies default sort' do
+        subject.add_sorting_to_solr(solr_params)
+        expect(solr_params[:sort]).to eq 'title_si asc'
+      end
+
+      it 'with query, does not apply default sort' do
+        subject.add_sorting_to_solr(solr_params.merge(q: 'Abraham Lincoln'))
+        expect(solr_params[:sort]).not_to eq 'title_si asc'
+      end
+    end
+  end
+
+  describe 'undefined access' do
+    subject { described_class.new(context) }
+    it_behaves_like 'common SearchBuilder'
+
+    describe '#discovery_permissions' do
+      it 'returns the inherited default permissions' do
+        expect(subject.discovery_permissions).to contain_exactly('read', 'discover', 'edit')
+      end
+    end
+  end
+
+  describe 'read access' do
+    subject { described_class.new(context, ['read']) }
+    it_behaves_like 'common SearchBuilder'
+
+    describe '#discovery_permissions' do
+      it 'returns the set permissions' do
+        expect(subject.discovery_permissions).to eq ['read']
+      end
+    end
+  end
+
+  describe 'edit access' do
+    subject { described_class.new(context, ['edit']) }
+    it_behaves_like 'common SearchBuilder'
+
+    describe '#discovery_permissions' do
+      it 'returns the set permissions' do
+        expect(subject.discovery_permissions).to eq ['edit']
+      end
     end
   end
 end

--- a/spec/search_builders/curation_concerns/collection_search_builder_spec.rb
+++ b/spec/search_builders/curation_concerns/collection_search_builder_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CurationConcerns::CollectionSearchBuilder do
+  let(:context) { double('context') }
+  let(:solr_params) { { fq: [] } }
+
+  subject { described_class.new(context, :read) }
+  describe '#filter_models' do
+    before { subject.filter_models(solr_params) }
+
+    it 'adds Collection to :fq' do
+      expect(solr_params[:fq].first).to include('{!field f=has_model_ssim}Collection')
+    end
+  end
+end


### PR DESCRIPTION
- Move `configure_blacklight` out one level (from `SelectsCollections` to `CollectionsControllerBehavior`)
- Make `CollectionSearchBuilder` more aware of its inheritance.  Use overriding and initialization instead of adding incessantly to the processor_chain.  We aren't the first ones in this stack to think of sorting by a field or row counts.
- Avoid confusing `discovery_permissions` => `@discovery_perms` accessor, redundant to @discovery_permissions, oddly.
- Cleanup unnecessary overrides. 
- Add a big README for SearchBuilders
