### PR TITLE
Making the permissions controller use a behavior so we can extend the behavior 

### DIFF
--- a/app/controllers/concerns/curation_concerns/permissions_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/permissions_controller_behavior.rb
@@ -1,0 +1,23 @@
+module CurationConcerns
+  module PermissionsControllerBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      include CurationConcerns::CurationConcernController
+
+      def confirm
+      end
+
+      def copy
+        authorize! :edit, curation_concern
+        VisibilityCopyJob.perform_later(curation_concern)
+        flash_message = 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
+        redirect_to [main_app, curation_concern], notice: flash_message
+      end
+
+      def curation_concern
+        @curation_concern ||= ActiveFedora::Base.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/curation_concerns/permissions_controller.rb
+++ b/app/controllers/curation_concerns/permissions_controller.rb
@@ -1,18 +1,3 @@
 class CurationConcerns::PermissionsController < ApplicationController
-  include CurationConcerns::CurationConcernController
-  with_themed_layout '1_column'
-
-  def confirm
-  end
-
-  def copy
-    authorize! :edit, curation_concern
-    VisibilityCopyJob.perform_later(curation_concern)
-    flash_message = 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
-    redirect_to [main_app, curation_concern], notice: flash_message
-  end
-
-  def curation_concern
-    @curation_concern ||= ActiveFedora::Base.find(params[:id])
-  end
+  include CurationConcerns::PermissionsControllerBehavior
 end


### PR DESCRIPTION
Since Sufia has additional permissions that curation does not have we need the ability to extend the permission copying behavior.

Changes proposed in this pull request:
* Add a behavior for the controller 
* Use the added behavior in the controller

@projecthydra/sufia-code-reviewers

