### PR TITLE
rights label uses LicenseService

### DIFF
--- a/app/renderers/curation_concerns/renderers/rights_attribute_renderer.rb
+++ b/app/renderers/curation_concerns/renderers/rights_attribute_renderer.rb
@@ -19,7 +19,7 @@ module CurationConcerns
           if parsed_uri.nil?
             ERB::Util.h(value)
           else
-            %(<a href=#{ERB::Util.h(value)} target="_blank">#{RightsService.label(value)}</a>)
+            %(<a href=#{ERB::Util.h(value)} target="_blank">#{CurationConcerns::LicenseService.new.label(value)}</a>)
           end
         end
     end


### PR DESCRIPTION
Fixes projecthydra-labs/geo_concerns#182

RightsService was deprecated but the rights_attribute_renderer uses it. Updates method to use the preferred CurationConcerns::LicenseService.

@projecthydra/sufia-code-reviewers

