### PR TITLE
Add configurable administrative dashboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Docs: [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.sv
 
 Join in: [![Slack Status](http://slack.projecthydra.org/badge.svg)](http://slack.projecthydra.org/) [![Ready](https://badge.waffle.io/projecthydra/curation_concerns.svg?label=ready&title=Ready)](http://waffle.io/projecthydra/curation_concerns)
 
-
 A Hydra-based Rails Engine that extends an application, adding the ability to Create, Read, Update and Destroy (CRUD) objects (based on [Hydra::Works](http://github.com/projecthydra/hydra-works)) and providing a generator for defining object types with custom workflows, views, access controls, etc.
 
 ## Prerequisites
@@ -108,6 +107,19 @@ fcrepo_wrapper -p 8986 --no-jms
 rake engine_cart:generate
 rake curation_concerns:spec
 ```
+
+### Adding Sample Data to Test Application
+
+Sometimes when working with the test application, it can be helpful to have a repository populated with some number of objects. Rather than having to create them all through the user interface, which can be timely, the test application bundled with CurationConcerns provides a rake task that automatically creates 24 objects in the test application repository with different titles, levels of visibility, embargoes, and leases:
+
+``` bash
+cd .internal_test_app
+rake db:seed
+```
+
+### Configuring the Administration Panel
+
+To configure the Administration Pane see [Admin Menu Guide](https://github.com/projecthydra/curation_concerns/wiki/Admin-Menu)
 
 ## Help
 

--- a/app/assets/javascripts/curation_concerns/charts.js
+++ b/app/assets/javascripts/curation_concerns/charts.js
@@ -1,0 +1,45 @@
+//= require jquery.flot
+//= require jquery.flot.pie
+//= require jquery.flot.resize
+
+(function( $ ){
+  $.fn.doughnut_chart = function( data ) {
+    $.plot(this, data,
+         {
+           series: {
+             pie: {
+               innerRadius: 0.5,
+               show: true,
+               radius: 1,
+               label: {
+                 show: true,
+                 radius: 3/4,
+                 formatter: labelFormatter,
+                 background: {
+                   opacity: 0.5,
+                   color: '#000'
+                 }
+               }
+             }
+           },
+           legend: {
+             show: false
+           },
+           grid: {
+             hoverable: true
+           }
+         }
+        );
+
+    function labelFormatter(label, series) {
+      return "<div style='font-size:8pt; text-align:center; padding:2px; color:white;'>" + label + "<br/>" + Math.round(series.percent) + "%</div>";
+    }
+  };
+})( jQuery );
+
+Blacklight.onLoad(function () {
+    $('.stats-doughnut').each (function () {
+      data = $(this).data('flot');
+      $(this).doughnut_chart(data);
+    });
+});

--- a/app/assets/javascripts/curation_concerns/curation_concerns.js
+++ b/app/assets/javascripts/curation_concerns/curation_concerns.js
@@ -10,6 +10,7 @@
 //= require curation_concerns/collections
 //= require curation_concerns/file_manager
 //= require curation_concerns/boot
+//= require curation_concerns/charts
 //= require babel/polyfill
 
 // Initialize plugins and Bootstrap dropdowns on jQuery's ready event as well as

--- a/app/assets/stylesheets/curation_concerns/admin.scss
+++ b/app/assets/stylesheets/curation_concerns/admin.scss
@@ -1,0 +1,141 @@
+@import 'widgets';
+@import 'bootstrap';
+
+$sidebar-background-color: #5f5f5f !default;
+$sidebar-separator-color: #555 !default;
+$sidebar-link-color: #ffffff !default;
+$sidebar-icon-color: #ffffff !default;
+$sidebar-hover-background-color: #7f7f7f !default;
+$sidebar-selected-background-color: #7f7f7f !default;
+$sidebar-hover-icon-color: #eee !default;
+
+$header-background-color: black !default;
+$header-text-color: #f7f7f7 !default;
+$header-logo-color: #ffffff !default;
+$header-height: 35px !default;
+$title-text-color: #4e4a42 !default;
+$content-background-color: #5f5f5f !default;
+
+
+html, body {
+  height: 100%;
+}
+
+#banner {
+  @include make-xs-column(12);
+}
+
+.page-container {
+  @include make-row;
+  min-height: 100%;
+  background: $sidebar-background-color;
+}
+
+.page-container .page-sidebar {
+  @include make-xs-column(3);
+  color: #ddd;
+  z-index: 3;
+}
+
+.page-container .page-content {
+  min-height: 100%;
+  background: $content-background-color;
+  @include make-xs-column(9);
+}
+
+.x-navigation {
+  width: 100%;
+  padding: 0px;
+  margin: 0px;
+  float: left;
+  list-style: none;
+  display: block;
+  background: $sidebar-background-color;
+}
+
+.x-navigation li {
+  float: left;
+  display: block;
+  width: 100%;
+  padding: 0px;
+  margin: 0px;
+  position: relative;
+}
+
+.x-navigation li > a {
+  display: block;
+  width: 100%;
+  line-height: 19px;
+  color: $sidebar-link-color;
+  font-size: 13px;
+  font-weight: 400;
+  text-decoration: none;
+  padding: 15px 10px 15px 15px;
+  border-bottom: 1px solid $sidebar-separator-color;
+}
+
+.x-navigation li > a .fa {
+  color: $sidebar-icon-color;
+  margin-right: 10px;
+  transition: color 200ms ease;
+}
+
+.x-navigation li > a.selected {
+  background: $sidebar-selected-background-color;
+}
+
+.x-navigation li > a:hover {
+  background: $sidebar-hover-background-color;
+  transition: all 200ms ease;
+}
+
+.x-navigation li > a:hover .fa {
+  color: $sidebar-hover-icon-color;
+}
+
+.x-navigation.x-navigation-horizontal {
+  height: $header-height;
+  background: $header-background-color;
+  border-color: $header-background-color;
+}
+
+.x-navigation.x-navigation-horizontal li {
+  position: relative;
+}
+
+.x-navigation.x-navigation-horizontal > li {
+  width: auto;
+}
+
+.x-navigation.x-navigation-horizontal > li > a {
+  padding: 10px;
+  border-bottom: 0px;
+  line-height: 20px;
+  color: $header-text-color;
+}
+
+.dashboard-index {
+  @include container-fixed;
+  > .wrapper {
+    @include make-row;
+  }
+}
+
+@mixin widget-partial($col: 12) {
+  @include make-sm-column(12);
+  @include make-md-column($col);
+  .partial-wrapper {
+    @extend .widget;
+    @extend .widget-default;
+  }
+}
+
+.partial-total_objects {
+  @include widget-partial;
+}
+.partial-total_objects_charts {
+  @include widget-partial(6);
+}
+.partial-total_embargo_visibility {
+  @include widget-partial(6);
+}

--- a/app/assets/stylesheets/curation_concerns/widgets.css
+++ b/app/assets/stylesheets/curation_concerns/widgets.css
@@ -1,0 +1,239 @@
+/* WIDGETS */
+.widget {
+  width: 100%;
+  float: left;
+  margin: 0px;
+  list-style: none;
+  text-decoration: none;
+  -moz-box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 1px 1px 0px rgba(0, 0, 0, 0.2);
+  color: #FFF;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+  padding: 15px 10px;
+  margin-bottom: 20px;
+  min-height: 120px;
+  position: relative;
+}
+.widget.widget-padding-sm,
+.widget.widget-item-icon {
+  padding: 10px 0px 5px;
+}
+.widget.widget-np {
+  padding: 0px;
+}
+.widget.widget-no-subtitle {
+  padding-top: 25px;
+}
+.widget.widget-carousel {
+  padding-bottom: 0px;
+  padding-top: 10px;
+}
+.widget.widget-default {
+  background: #ffffff;
+  background: -moz-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #ffffff), color-stop(100%, #f5f5f5));
+  background: -webkit-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background: -o-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background: -ms-linear-gradient(top, #ffffff 0%, #f5f5f5 100%);
+  background: linear-gradient(to bottom, #ffffff 0%, #f5f5f5 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#ffffff, endColorstr=#f5f5f5, GradientType=0);
+}
+
+.widget .widget-title,
+.widget .widget-subtitle,
+.widget .widget-int,
+.widget .widget-big-int {
+  width: 100%;
+  float: left;
+  text-align: center;
+}
+.widget .widget-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 5px;
+  line-height: 20px;
+  text-transform: uppercase;
+}
+.widget .widget-subtitle {
+  font-size: 12px;
+  font-weight: 400;
+  margin-bottom: 5px;
+  line-height: 15px;
+  color: #EEE;
+}
+.widget .widget-int {
+  font-size: 32px;
+  line-height: 40px;
+  font-weight: bold;
+  font-family: arial;
+}
+.widget .widget-big-int {
+  font-size: 42px;
+  line-height: 45px;
+  font-weight: 300;
+}
+.widget .widget-item-left {
+  margin-left: 10px;
+  float: left;
+  width: 100px;
+}
+.widget .widget-item-right {
+  margin-right: 10px;
+  float: right;
+  width: 100px;
+}
+.widget.widget-item-icon .widget-item-left,
+.widget.widget-item-icon .widget-item-right {
+  width: 70px;
+  padding: 20px 0px;
+  text-align: center;
+}
+.widget.widget-item-icon .widget-item-left {
+  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  margin-right: 10px;
+  padding-right: 10px;
+}
+.widget.widget-item-icon .widget-item-right {
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+  margin-left: 10px;
+  padding-left: 10px;
+}
+.widget .widget-item-left .fa,
+.widget .widget-item-right .fa,
+.widget .widget-item-left .glyphicon,
+.widget .widget-item-right .glyphicon {
+  font-size: 60px;
+}
+.widget .widget-data {
+  padding-left: 120px;
+}
+.widget .widget-data-left {
+  padding-right: 120px;
+}
+.widget.widget-item-icon .widget-data {
+  padding-left: 90px;
+}
+.widget.widget-item-icon .widget-data-left {
+  padding-right: 90px;
+  padding-left: 10px;
+}
+.widget .widget-data .widget-title,
+.widget .widget-data-left .widget-title,
+.widget .widget-data .widget-subtitle,
+.widget .widget-data-left .widget-subtitle,
+.widget .widget-data .widget-int,
+.widget .widget-data-left .widget-int,
+.widget .widget-data .widget-big-int,
+.widget .widget-data-left .widget-big-int {
+  text-align: left;
+}
+.widget .widget-controls a {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  text-align: center;
+  line-height: 27px;
+  color: #FFF;
+  border: 1px solid #FFF;
+  -moz-border-radius: 50%;
+  -webkit-border-radius: 50%;
+  border-radius: 50%;
+  -webkit-transition: all 200ms ease;
+  -moz-transition: all 200ms ease;
+  -ms-transition: all 200ms ease;
+  -o-transition: all 200ms ease;
+  transition: all 200ms ease;
+  opacity: 0.4;
+  filter: alpha(opacity = 40);
+}
+.widget .widget-controls a.widget-control-left {
+  left: 10px;
+  top: 10px;
+}
+.widget .widget-controls a.widget-control-right {
+  right: 10px;
+  top: 10px;
+}
+.widget .widget-controls a:hover {
+  opacity: 1;
+  filter: alpha(opacity = 100);
+}
+.widget .widget-buttons {
+  float: left;
+  width: 100%;
+  text-align: center;
+  padding-top: 3px;
+  margin-top: 5px;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+.widget .widget-buttons a {
+  position: relative;
+  display: inline-block;
+  line-height: 30px;
+  font-size: 21px;
+}
+.widget .widget-buttons .col {
+  width: 100%;
+  float: left;
+}
+.widget .widget-buttons.widget-c2 .col {
+  width: 50%;
+}
+.widget .widget-buttons.widget-c3 .col {
+  width: 33.333333%;
+}
+.widget .widget-buttons.widget-c4 .col {
+  width: 25%;
+}
+.widget .widget-buttons.widget-c5 .col {
+  width: 20%;
+}
+.widget.widget-primary .widget-buttons a {
+  color: #11100e;
+  border-color: #11100e;
+}
+.widget.widget-primary .widget-buttons a:hover {
+  color: #000000;
+}
+.widget.widget-success .widget-buttons a {
+  color: #51672e;
+  border-color: #51672e;
+}
+.widge.widget-success .widget-buttons a:hover {
+  color: #435526;
+}
+.widget.widget-info .widget-buttons a {
+  color: #14708f;
+  border-color: #14708f;
+}
+.widget.widget-info .widget-buttons a:hover {
+  color: #115f79;
+}
+.widget.widget-warning .widget-buttons a {
+  color: #a15e01;
+  border-color: #a15e01;
+}
+.widget.widget-warning .widget-buttons a:hover {
+  color: #874f01;
+}
+.widget.widget-danger .widget-buttons a {
+  color: #5a2222;
+  border-color: #5a2222;
+}
+.widget.widget-danger .widget-buttons a:hover {
+  color: #471b1b;
+}
+
+.widget.widget-default {
+  color: #4e4a42;
+}
+.widget.widget-default .widget-subtitle {
+  color: #4e4a42;
+}
+.widget.widget-default .widget-controls a {
+  color: #4e4a42;
+  border-color: #4e4a42;
+}

--- a/app/controllers/concerns/curation_concerns/admin_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/admin_controller_behavior.rb
@@ -1,0 +1,32 @@
+module CurationConcerns
+  module AdminControllerBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      cattr_accessor :configuration
+      self.configuration = CurationConcerns.config.dashboard_configuration
+      before_action :require_permissions
+      before_action :load_configuration
+      layout "admin"
+
+      def index
+        render "index"
+      end
+    end
+
+    private
+
+      def require_permissions
+        authorize! :read, :admin_dashboard
+      end
+
+      def load_configuration
+        @configuration = self.class.configuration.with_indifferent_access
+      end
+
+      # Loads the index action if it's only defined in the configuration.
+      def action_missing(action)
+        index if @configuration[:actions].include?(action)
+      end
+  end
+end

--- a/app/controllers/curation_concerns/admin_controller.rb
+++ b/app/controllers/curation_concerns/admin_controller.rb
@@ -1,0 +1,61 @@
+module CurationConcerns
+  # Controller for displaying the Administration console.
+  #
+  # This controller provides a framework for reading in a configuration
+  #  and displaying administrative widgets on an admistrative dashboard.
+  #
+  # This configuration is included in config/initializers/curation_concerns.rb
+  #
+  # The administrative dashbord is divided into two columns, a left side menu
+  #  and the right action display.
+  #
+  # The menu is configured by listing actions in display order.
+  #
+  # The actions are then defined in the configuration and
+  # automatically display the partials listed. You can override
+  # this default behavior by implementing your action in the controller.
+  #
+  # The configuration also includes named data sources that can be used in
+  #  any view to access system level data.
+  #
+  # Example Configuration:
+  #       @dashboard_configuration ||= {
+  #         menu: {
+  #             index: {},
+  #             other_action: {},
+  #             complex_action: {}
+  #         },
+  #         actions: {
+  #           index: {
+  #               partials: [
+  #                   "total_objects"
+  #               ]
+  #           },
+  #           other_action: {
+  #               partials: [
+  #                   "other_objects_view"
+  #               ]
+  #           },
+  #           complex_action: {
+  #               # rendered in the action
+  #           }
+  #         },
+  #         data_sources: {
+  #           resource_stats: CurationConcerns::ResourceStatisticsSource
+  #         }
+  #      }
+  #
+  # Example AdminController
+  #      class AdminController < ApplicationController
+  #         include CurationConcerns::AdminControllerBehavior
+  #
+  #         def complex_action
+  #            # do complex stuff and render how I want
+  #            ...
+  #         end
+  #      end
+  #
+  class AdminController < ApplicationController
+    include CurationConcerns::AdminControllerBehavior
+  end
+end

--- a/app/helpers/curation_concerns/charts_helper.rb
+++ b/app/helpers/curation_concerns/charts_helper.rb
@@ -1,0 +1,7 @@
+module CurationConcerns
+  module ChartsHelper
+    def hash_to_flot(data)
+      data.map { |key, value| { label: key, data: value } }
+    end
+  end
+end

--- a/app/helpers/curation_concerns/main_app_helpers.rb
+++ b/app/helpers/curation_concerns/main_app_helpers.rb
@@ -8,4 +8,5 @@ module CurationConcerns::MainAppHelpers
   include CurationConcerns::EmbargoHelper
   include CurationConcerns::LeaseHelper
   include CurationConcerns::CollectionsHelper
+  include CurationConcerns::ChartsHelper
 end

--- a/app/models/concerns/curation_concerns/ability.rb
+++ b/app/models/concerns/curation_concerns/ability.rb
@@ -28,6 +28,7 @@ module CurationConcerns
     end
 
     def admin_permissions
+      can :read, :admin_dashboard
       alias_action :edit, to: :update
       alias_action :show, to: :read
       alias_action :discover, to: :read

--- a/app/sources/curation_concerns/resource_statistics_source.rb
+++ b/app/sources/curation_concerns/resource_statistics_source.rb
@@ -1,0 +1,82 @@
+module CurationConcerns
+  class ResourceStatisticsSource
+    attr_accessor :search_builder, :repository
+    def initialize(search_builder: ::CatalogController.new.search_builder, repository: ::CatalogController.new.repository)
+      # Remove gated discovery.
+      @search_builder = search_builder.except(:add_access_controls_to_solr_params)
+      @repository = repository
+      solr_arguments[:fq] ||= []
+      solr_arguments[:rows] = 0
+    end
+
+    def open_concerns_count
+      results_count("#{Hydra.config.permissions.read.group}:public")
+    end
+
+    def authenticated_concerns_count
+      results_count("#{Hydra.config.permissions.read.group}:registered")
+    end
+
+    def restricted_concerns_count
+      # TODO: Replace this with a query that that returns all documents that
+      #       either lack the `read_access_group_ssim` key, or have the key
+      #       without the values of `public` or `registered`
+      repository.search(solr_arguments)["response"]["numFound"] - (authenticated_concerns_count + open_concerns_count)
+    end
+
+    def expired_embargo_now_authenticated_concerns_count
+      results_count(["#{Hydra.config.permissions.read.group}:registered", "embargo_history_ssim:*"])
+    end
+
+    def expired_embargo_now_open_concerns_count
+      results_count(["#{Hydra.config.permissions.read.group}:public", "embargo_history_ssim:*"])
+    end
+
+    def active_embargo_now_authenticated_concerns_count
+      results_count(["#{Hydra.config.permissions.read.group}:registered", "embargo_release_date_dtsi:[NOW TO *]"])
+    end
+
+    def active_embargo_now_restricted_concerns_count
+      # TODO: Replace the subtraction with another `#where` query that returns
+      #       all actively embargoed documents that either lack the
+      #       `read_access_group_ssim` key, or have the key without the values
+      #       of `public` or `registered`
+      all_expired_embargos = results_count("embargo_release_date_dtsi:[NOW TO *]")
+      all_expired_embargos - active_embargo_now_authenticated_concerns_count
+    end
+
+    def expired_lease_now_authenticated_concerns_count
+      results_count(["#{Hydra.config.permissions.read.group}:registered", "lease_history_ssim:*"])
+    end
+
+    def expired_lease_now_restricted_concerns_count
+      # TODO: Replace the subtraction with another `#where` query that returns
+      #       all expired lease documents that either lack the
+      #       `read_access_group_ssim` key, or have the key without the values
+      #       of `public` or `registered`
+      all_leased_documents = results_count("lease_history_ssim:*")
+      all_leased_documents - expired_lease_now_authenticated_concerns_count
+    end
+
+    def active_lease_now_authenticated_concerns_count
+      results_count(["#{Hydra.config.permissions.read.group}:registered", "lease_expiration_date_dtsi:[NOW TO *]"])
+    end
+
+    def active_lease_now_open_concerns_count
+      results_count(["#{Hydra.config.permissions.read.group}:public", "lease_expiration_date_dtsi:[NOW TO *]"])
+    end
+
+    private
+
+      def solr_arguments
+        @solr_arguments ||= search_builder.to_h
+      end
+
+      def results_count(query)
+        q = { fq: Array.wrap(query) }
+        repository.search(solr_arguments.merge(q) do |_key, v1, v2|
+          v1 + v2
+        end)["response"]["numFound"]
+      end
+  end
+end

--- a/app/views/curation_concerns/admin/_admin_menu.html.erb
+++ b/app/views/curation_concerns/admin/_admin_menu.html.erb
@@ -1,0 +1,5 @@
+<% configuration[:menu].each do |key, config| %>
+  <li>
+    <%= link_to t("curation_concerns.dashboard.menu.#{key}"), curation_concerns.url_for(controller: :"curation_concerns/admin", action: key, only_path: true), class: action_name == key ? 'selected' : ''%>
+  </li>
+<% end %>

--- a/app/views/curation_concerns/admin/_resource_stats.html.erb
+++ b/app/views/curation_concerns/admin/_resource_stats.html.erb
@@ -1,0 +1,41 @@
+<h4>Totals by Visibility</h4>
+
+<table class="table table-striped">
+  <tr>
+    <th>Visibility</th>
+    <th>Count</th>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.open.text") %></td><td><span class="count"><%= resource_stats.open_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.authenticated.text") %></td><td><span class="count"><%= resource_stats.authenticated_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.restricted.text") %></td><td><span class="count"><%= resource_stats.restricted_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.embargo.expired.authenticated.text") %></td><td><span class="count"><%= resource_stats.expired_embargo_now_authenticated_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.embargo.expired.open.text") %></td><td><span class="count"><%= resource_stats.expired_embargo_now_open_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.embargo.active.authenticated.text") %></td><td><span class="count"><%= resource_stats.active_embargo_now_authenticated_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.embargo.active.restricted.text") %></td><td><span class="count"><%= resource_stats.active_embargo_now_restricted_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.lease.expired.restricted.text") %></td><td><span class="count"><%= resource_stats.expired_lease_now_restricted_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.lease.expired.authenticated.text") %></td><td><span class="count"><%= resource_stats.expired_lease_now_authenticated_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.lease.active.authenticated.text") %></td><td><span class="count"><%= resource_stats.active_lease_now_authenticated_concerns_count %></span></td>
+  </tr>
+  <tr>
+    <td><%= t("curation_concerns.visibility.lease.active.open.text") %></td><td><span class="count"><%= resource_stats.active_lease_now_open_concerns_count %></span></td>
+  </tr>
+</table>

--- a/app/views/curation_concerns/admin/_sidebar.html.erb
+++ b/app/views/curation_concerns/admin/_sidebar.html.erb
@@ -1,0 +1,6 @@
+                <!-- START X-NAVIGATION -->
+                <ul class="x-navigation">
+                    <li class="xn-logo">
+                      <%= render "admin_menu", configuration: @configuration %>
+                    </li>
+                </ul>

--- a/app/views/curation_concerns/admin/_total_embargo_visibility.html.erb
+++ b/app/views/curation_concerns/admin/_total_embargo_visibility.html.erb
@@ -1,0 +1,13 @@
+<% resource_stats = @configuration[:data_sources][:resource_stats].new %>
+    <h4>Embargos & Leases</h4>
+      <%= render "curation_concerns/admin/widgets/doughnut", label: "embargo",
+              data: {
+                  t("curation_concerns.visibility.embargo.expired.authenticated.text") => resource_stats.expired_embargo_now_authenticated_concerns_count,
+                  t("curation_concerns.visibility.embargo.expired.open.text") => resource_stats.expired_embargo_now_open_concerns_count,
+                  t("curation_concerns.visibility.lease.active.authenticated.text") => resource_stats.active_lease_now_authenticated_concerns_count,
+                  t("curation_concerns.visibility.embargo.active.authenticated.text") => resource_stats.active_embargo_now_authenticated_concerns_count,
+                  t("curation_concerns.visibility.lease.expired.restricted.text") => resource_stats.expired_lease_now_restricted_concerns_count,
+                  t("curation_concerns.visibility.lease.expired.authenticated.text") => resource_stats.expired_lease_now_authenticated_concerns_count,
+                  t("curation_concerns.visibility.lease.active.open.text") => resource_stats.active_lease_now_open_concerns_count,
+                  t("curation_concerns.visibility.embargo.active.restricted.text") => resource_stats.active_embargo_now_restricted_concerns_count
+              }  %>

--- a/app/views/curation_concerns/admin/_total_objects.html.erb
+++ b/app/views/curation_concerns/admin/_total_objects.html.erb
@@ -1,0 +1,2 @@
+<% resource_stats = @configuration[:data_sources][:resource_stats].new %>
+<%= render "resource_stats", resource_stats: resource_stats %>

--- a/app/views/curation_concerns/admin/_total_objects_charts.html.erb
+++ b/app/views/curation_concerns/admin/_total_objects_charts.html.erb
@@ -1,0 +1,8 @@
+<% resource_stats = @configuration[:data_sources][:resource_stats].new %>
+    <h4>Visibility</h4>
+      <%= render "curation_concerns/admin/widgets/doughnut", label: "visibility",
+              data: {
+                  t("curation_concerns.visibility.open.text") => resource_stats.open_concerns_count,
+                  t("curation_concerns.visibility.authenticated.text") => resource_stats.authenticated_concerns_count,
+                  t("curation_concerns.visibility.restricted.text") =>  resource_stats.restricted_concerns_count
+              } %>

--- a/app/views/curation_concerns/admin/index.html.erb
+++ b/app/views/curation_concerns/admin/index.html.erb
@@ -1,0 +1,11 @@
+<div class="<%= "dashboard-#{action_name}" %>">
+  <div class="wrapper">
+    <% @configuration[:actions][action_name][:partials].each do |partial_name| %>
+      <div class="<%= "partial-#{partial_name}" %>">
+        <div class="partial-wrapper">
+          <%= render partial_name %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/curation_concerns/admin/widgets/_doughnut.html.erb
+++ b/app/views/curation_concerns/admin/widgets/_doughnut.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag :div, '', id: "#{label}-stats-doughnut", class: "stats-doughnut", data: { label: "#{label}_data", flot: hash_to_flot(data) }, style: "height: 300px;" %>

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -1,0 +1,13 @@
+<%= csrf_meta_tag %>
+<meta charset="utf-8" />
+
+<!-- added for use on small devices like phones -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
+<title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
+
+<!-- application css -->
+<%= stylesheet_link_tag 'application' %>
+
+<!-- application js -->
+<%= javascript_include_tag 'application' %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- META SECTION -->
+    <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+
+    <%= render "layouts/head_tag_content"%>
+    <!-- END META SECTION -->
+
+    <!-- CSS INCLUDE -->
+    <%= stylesheet_link_tag 'curation_concerns/admin' %>
+    <!-- EOF CSS INCLUDE -->
+  </head>
+  <body>
+    <!-- START PAGE CONTAINER -->
+    <div class="page-container">
+      <header id="banner" role="banner">
+        <hgroup>
+        <%= render 'shared/brand_bar' %>
+        </hgroup>
+      </header>
+      <!-- START PAGE SIDEBAR -->
+      <div class="page-sidebar">
+        <%= render 'curation_concerns/admin/sidebar' %>
+      </div>
+      <!-- END PAGE SIDEBAR -->
+
+      <!-- PAGE CONTENT -->
+      <div class="page-content">
+
+        <!-- PAGE CONTENT WRAPPER -->
+        <div class="page-content-wrap">
+          <%= yield %>
+        </div>
+        <!-- END PAGE CONTENT WRAPPER -->
+      </div>
+      <!-- END PAGE CONTENT -->
+    </div>
+    <!-- END PAGE CONTAINER -->
+  </body>
+</html>

--- a/app/views/shared/_my_actions.html.erb
+++ b/app/views/shared/_my_actions.html.erb
@@ -20,6 +20,9 @@
       <% if can? :discover, Hydra::AccessControls::Lease %>
         <li><%= link_to 'Leases', main_app.leases_path, role: 'menuitem' %></li>
       <% end %>
+      <% if can? :read, :admin_dashboard %>
+        <li><%= link_to 'Admin Dashboard', curation_concerns.admin_root_path, role: 'menuitem' %></li>
+      <% end %>
 
       <% if include_works_link || include_collections_link %>
         <li class="divider"></li>

--- a/config/initializers/precompile_assets.rb
+++ b/config/initializers/precompile_assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( curation_concerns/admin.css )

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -113,10 +113,30 @@ en:
         text: "Embargo"
         class: "label-warning"
         label_html: <span class="label label-warning">Embargo</span>
+        expired:
+          authenticated:
+            text: "Embargo (Expired, Authenticated)"
+          open:
+            text: "Embargo (Expired, Open)"
+        active:
+          authenticated:
+            text: "Embargo (Active, Authenticated)"
+          restricted:
+            text: "Embargo (Active, Restricted)"
       lease:
         text: "Lease"
         class: "label-warning"
         label_html: <span class="label label-warning">Lease</span>
+        active:
+          authenticated:
+            text: "Lease (Active, Authenticated)"
+          open:
+            text: "Lease (Active, Open)"
+        expired:
+          authenticated:
+            text: "Lease (Expired, Authenticated)"
+          restricted:
+            text: "Lease (Expired, Restricted)"
       private:
         label_html: <span class="label label-danger">Private</span> Only users and/or groups that have been given specific access in the "Share With" section.
       restricted:
@@ -143,6 +163,9 @@ en:
       expiration:
         time: "in %{value} hours"
         lesser_time: in less than one hour
+    dashboard:
+      menu:
+        index: "Admin Dashboard"
   blacklight:
     search:
       fields:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,11 @@ CurationConcerns::Engine.routes.draw do
   get 'single_use_link/generated/:id' => 'single_use_links#index', as: :generated_single_use_links
   delete 'single_use_link/:id/delete/:link_id' => 'single_use_links#destroy', as: :delete_single_use_link
 
+  namespace :admin do
+    root action: :index
+    get :resource_details
+  end
+
   # mount BrowseEverything::Engine => '/remote_files/browse'
   resources :classify_concerns, only: [:new, :create]
 

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'awesome_nested_set', '~> 3.0'
   spec.add_dependency 'browse-everything', '~> 0.10'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
+  spec.add_dependency 'flot-rails', '~> 0.0.7'
 
   spec.add_development_dependency 'solr_wrapper', '~> 0.16'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'

--- a/lib/curation_concerns/configuration.rb
+++ b/lib/curation_concerns/configuration.rb
@@ -164,6 +164,34 @@ module CurationConcerns
       @binaries_directory ||= "tmp/binaries"
     end
 
+    # @!attribute [w] dashboard_configuration
+    #   Configuration for dashboard rendering.
+    attr_writer :dashboard_configuration
+    def dashboard_configuration
+      @dashboard_configuration ||= {
+        menu: {
+          index: {},
+          resource_details: {}
+        },
+        actions: {
+          index: {
+            partials: [
+              "total_objects_charts",
+              "total_embargo_visibility"
+            ]
+          },
+          resource_details: {
+            partials: [
+              "total_objects"
+            ]
+          }
+        },
+        data_sources: {
+          resource_stats: CurationConcerns::ResourceStatisticsSource
+        }
+      }
+    end
+
     callback.enable :after_create_concern, :after_create_fileset,
                     :after_update_content, :after_revert_content,
                     :after_update_metadata, :after_import_local_file_success,

--- a/lib/curation_concerns/engine.rb
+++ b/lib/curation_concerns/engine.rb
@@ -16,6 +16,7 @@ module CurationConcerns
     require 'awesome_nested_set'
     require 'breadcrumbs_on_rails'
     require 'rdf/vocab'
+    require 'flot-rails'
 
     config.autoload_paths += %W(
       #{config.root}/app/actors/concerns

--- a/lib/generators/curation_concerns/sample_data_generator.rb
+++ b/lib/generators/curation_concerns/sample_data_generator.rb
@@ -1,0 +1,12 @@
+require 'rails/generators'
+
+module CurationConcerns
+  class SampleDataGenerator < Rails::Generators::Base
+    source_root File.expand_path('../templates', __FILE__)
+
+    desc 'This generator copies over a file that creates sample data via `rake db:seed`'
+    def copy_sample_data
+      copy_file 'db/seeds.rb', 'db/seeds.rb'
+    end
+  end
+end

--- a/lib/generators/curation_concerns/templates/db/seeds.rb
+++ b/lib/generators/curation_concerns/templates/db/seeds.rb
@@ -1,0 +1,94 @@
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+#
+# Examples:
+#
+#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
+#   Character.create(name: 'Luke', movie: movies.first)
+
+user = User.create(email: 'foo@example.org', password: 'foobarbaz')
+
+# Public
+3.times do |i|
+  GenericWork.create(title: ["Public #{i}"], read_groups: ['public']) do |work|
+    work.apply_depositor_metadata(user)
+  end
+end
+
+# Authenticated
+2.times do |i|
+  GenericWork.create(title: ["Authenticated #{i}"], read_groups: ['registered']) do |work|
+    work.apply_depositor_metadata(user)
+  end
+end
+
+# Private
+1.times do |i|
+  GenericWork.create(title: ["Private #{i}"]) do |work|
+    work.apply_depositor_metadata(user)
+  end
+end
+
+# Active, Private Embargo
+3.times do |i|
+  GenericWork.create(title: ["Active Private #{i}"]) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_embargo(Date.tomorrow.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+  end
+end
+
+# Active, Authenticated Embargo
+2.times do |i|
+  GenericWork.create(title: ["Active Authenticated #{i}"]) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_embargo(Date.tomorrow.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+  end
+end
+
+# Expired, Authenticated Embargo
+1.times do |i|
+  GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: ['registered']) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_embargo(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+  end
+end
+
+# Expired, Public Embargo
+3.times do |i|
+  GenericWork.create(title: ["Expired Public #{i}"], read_groups: ['public']) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_embargo(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+  end
+end
+
+# Active, Public Lease
+3.times do |i|
+  GenericWork.create(title: ["Active Public #{i}"], read_groups: ['public']) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_lease(Date.tomorrow.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
+  end
+end
+
+# Active, Authenticated Lease
+2.times do |i|
+  GenericWork.create(title: ["Active Authenticated #{i}"], read_groups: ['registered']) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_lease(Date.tomorrow.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
+  end
+end
+
+# Expired, Authenticated Lease
+1.times do |i|
+  GenericWork.create(title: ["Expired Authenticated #{i}"], read_groups: ['registered']) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_lease(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+  end
+end
+
+# Expired, Private Lease
+3.times do |i|
+  GenericWork.create(title: ["Expired Public #{i}"]) do |work|
+    work.apply_depositor_metadata(user)
+    work.apply_lease(Date.yesterday.to_s, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE)
+  end
+end

--- a/spec/abilities/admin_ability_spec.rb
+++ b/spec/abilities/admin_ability_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'cancan/matchers'
+
+describe CurationConcerns::Ability, type: :model do
+  context "with a registered user" do
+    let(:user) { create(:user) }
+    subject { Ability.new(user) }
+    it { is_expected.not_to be_able_to(:read, :admin_dashboard) }
+  end
+  context "with an administrative user" do
+    let(:user) { create(:admin) }
+    subject { Ability.new(user) }
+    it { is_expected.to be_able_to(:read, :admin_dashboard) }
+  end
+end

--- a/spec/controllers/curation_concerns/admin_controller_spec.rb
+++ b/spec/controllers/curation_concerns/admin_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe CurationConcerns::AdminController do
+  routes { CurationConcerns::Engine.routes }
+  describe "GET /admin" do
+    context "when you have permission" do
+      let(:user) { FactoryGirl.create(:admin) }
+      before do
+        allow(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
+      end
+      it "works" do
+        get :index
+        expect(response).to be_success
+      end
+    end
+    context "when they don't have permission" do
+      it "throws a CanCan error" do
+        get :index
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe "GET missing_thing" do
+    before do
+      # Add necessary route.
+      # TODO: Consider a different pattern for this.
+      CurationConcerns::Engine.routes.draw do
+        get '/admin/missing_thing' => 'admin#missing_thing'
+      end
+
+      allow(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
+    end
+    after do
+      Rails.application.reload_routes!
+    end
+    context "when it exists in the configuration" do
+      before do
+        config = CurationConcerns.config.dashboard_configuration
+        config[:actions] = config[:actions].merge(missing_thing: {})
+        described_class.configuration = config
+      end
+      it "renders index" do
+        get :missing_thing
+
+        expect(response).to render_template "index"
+      end
+    end
+  end
+end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -15,8 +15,14 @@ FactoryGirl.define do
 
     factory :public_generic_work, traits: [:public]
 
+    factory :authenticated_generic_work, traits: [:authenticated]
+
     trait :public do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    trait :authenticated do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
     end
 
     factory :work_with_one_file do
@@ -66,22 +72,29 @@ FactoryGirl.define do
     factory :with_embargo_date do
       transient do
         embargo_date { Date.tomorrow.to_s }
+        current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+        future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
       end
       factory :embargoed_work do
-        after(:build) { |work, evaluator| work.apply_embargo(evaluator.embargo_date, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+        after(:build) { |work, evaluator| work.apply_embargo(evaluator.embargo_date, evaluator.current_state, evaluator.future_state) }
       end
-
       factory :embargoed_work_with_files do
-        after(:build) { |work, evaluator| work.apply_embargo(evaluator.embargo_date, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+        after(:build) { |work, evaluator| work.apply_embargo(evaluator.embargo_date, evaluator.current_state, evaluator.future_state) }
         after(:create) { |work, evaluator| 2.times { work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user) } }
       end
+    end
 
-      factory :leased_work do
-        after(:build) { |work, evaluator| work.apply_lease(evaluator.embargo_date, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) }
+    factory :with_lease_date do
+      transient do
+        lease_date { Date.tomorrow.to_s }
+        current_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+        future_state { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
       end
-
+      factory :leased_work do
+        after(:build) { |work, evaluator| work.apply_lease(evaluator.lease_date, evaluator.current_state, evaluator.future_state) }
+      end
       factory :leased_work_with_files do
-        after(:build) { |work, evaluator| work.apply_lease(evaluator.embargo_date, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) }
+        after(:build) { |work, evaluator| work.apply_lease(evaluator.lease_date, evaluator.current_state, evaluator.future_state) }
         after(:create) { |work, evaluator| 2.times { work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user) } }
       end
     end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+feature 'admin dashboard' do
+  let(:user) { FactoryGirl.create(:user) }
+  context "when given permission" do
+    before do
+      allow_any_instance_of(CurationConcerns::AdminController).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
+    end
+    it "loads the sidebar" do
+      visit "/admin"
+      expect(page).to have_link "Admin Dashboard"
+    end
+  end
+end

--- a/spec/helpers/curation_concerns/charts_helper_spec.rb
+++ b/spec/helpers/curation_concerns/charts_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe CurationConcerns::ChartsHelper do
+  describe '#hash_to_flot' do
+    subject { helper.hash_to_flot(data) }
+    let(:data) do
+      {
+        'Foo' => 5,
+        'Bar' => 10
+      }
+    end
+    it { is_expected.to eq([{ label: 'Foo', data: 5 }, { label: 'Bar', data: 10 }]) }
+  end
+end

--- a/spec/javascripts/charts_spec.coffee
+++ b/spec/javascripts/charts_spec.coffee
@@ -1,0 +1,8 @@
+describe "Chart Generation", ->
+  beforeEach () ->
+    loadFixtures('chart_example.html')
+  describe "instantiation", ->
+    it "builds a chart for all stats doughnuts", ->
+      Blacklight.activate()
+      canvas = $(".stats-doughnut > canvas")
+      expect(canvas.length).not.toBeLessThan(1)

--- a/spec/javascripts/fixtures/chart_example.html
+++ b/spec/javascripts/fixtures/chart_example.html
@@ -1,0 +1,1 @@
+<div id="visibility-stats-pie" class="stats-doughnut" data-label="visibility_data" data-flot="[{&quot;label&quot;:&quot;Open Access&quot;,&quot;data&quot;:9},{&quot;label&quot;:&quot;Institution Name&quot;,&quot;data&quot;:9},{&quot;label&quot;:&quot;Private&quot;,&quot;data&quot;:9}]" style="height: 300px;"></div>

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -86,4 +86,11 @@ describe 'Routes', type: :routing do
       expect(get: '/downloads/9').to route_to(controller: 'downloads', action: 'show', id: '9')
     end
   end
+
+  describe 'Admin Dashboard' do
+    routes { CurationConcerns::Engine.routes }
+    it 'routes to the admin dashboard' do
+      expect(get: '/admin').to route_to(controller: 'curation_concerns/admin', action: 'index')
+    end
+  end
 end

--- a/spec/sources/curation_concerns/resource_statistics_source_spec.rb
+++ b/spec/sources/curation_concerns/resource_statistics_source_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe CurationConcerns::ResourceStatisticsSource do
+  subject { described_class.new }
+  describe "#open_concerns_count" do
+    it "returns the number of open concerns" do
+      create :private_generic_work
+      expect(subject.open_concerns_count).to eq(0)
+    end
+
+    context "when I have concerns" do
+      before do
+        create :public_generic_work
+      end
+      it "returns the number of open concerns" do
+        expect(subject.open_concerns_count).to eq(1)
+      end
+    end
+  end
+
+  describe "#authenticated_concerns_count" do
+    context "when I have concerns" do
+      before do
+        create :authenticated_generic_work
+      end
+      it "returns the number of open concerns" do
+        expect(subject.authenticated_concerns_count).to eq(1)
+      end
+    end
+  end
+
+  describe "#restricted_concerns_count" do
+    context "when I have concerns" do
+      before do
+        create :generic_work
+      end
+      it "returns the number of open concerns" do
+        expect(subject.restricted_concerns_count).to eq(1)
+      end
+    end
+  end
+
+  describe "embargoes" do
+    before do
+      create :embargoed_work, embargo_date: embargo_date, current_state: current_state, future_state: future_state
+      create :public_generic_work
+      create :authenticated_generic_work
+      create :private_generic_work
+    end
+
+    describe "#active_embargo_now_authenticated_concerns_count" do
+      let(:embargo_date) { Date.tomorrow.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      it "returns the number of embargo concerns" do
+        expect(subject.active_embargo_now_authenticated_concerns_count).to eq(1)
+      end
+    end
+
+    describe "#active_embargo_now_restricted_concerns_count" do
+      let(:embargo_date) { Date.tomorrow.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      it "returns the number of embargo concerns" do
+        expect(subject.active_embargo_now_restricted_concerns_count).to eq(1)
+      end
+    end
+
+    describe "#expired_embargo_now_authenticated_concerns_count" do
+      let(:embargo_date) { Date.yesterday.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      it "returns the number of embargo concerns" do
+        expect(subject.expired_embargo_now_authenticated_concerns_count).to eq(1)
+      end
+    end
+
+    describe "#expired_embargo_now_open_concerns_count" do
+      let(:embargo_date) { Date.yesterday.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      it "returns the number of embargo concerns" do
+        expect(subject.expired_embargo_now_open_concerns_count).to eq(1)
+      end
+    end
+  end
+
+  describe "leases" do
+    before do
+      create :leased_work, lease_date: lease_date, current_state: current_state, future_state: future_state
+      create :public_generic_work
+      create :authenticated_generic_work
+      create :private_generic_work
+    end
+
+    describe "#active_lease_now_authenticated_concerns_count" do
+      let(:lease_date) { Date.tomorrow.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      it "returns the number of lease concerns" do
+        expect(subject.active_lease_now_authenticated_concerns_count).to eq(1)
+      end
+    end
+
+    describe "#active_lease_now_open_concerns_count" do
+      let(:lease_date) { Date.tomorrow.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      it "returns the number of lease concerns" do
+        expect(subject.active_lease_now_open_concerns_count).to eq(1)
+      end
+    end
+
+    describe "#expired_lease_now_authenticated_concerns_count" do
+      let(:lease_date) { Date.yesterday.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      it "returns the number of lease concerns" do
+        expect(subject.expired_lease_now_authenticated_concerns_count).to eq(1)
+      end
+    end
+
+    describe "#expired_lease_now_restricted_concerns_count" do
+      let(:lease_date) { Date.yesterday.to_s }
+      let(:current_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+      let(:future_state) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+      it "returns the number of lease concerns" do
+        expect(subject.expired_lease_now_restricted_concerns_count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -20,4 +20,8 @@ class TestAppGenerator < Rails::Generators::Base
     remove_file 'spec/controllers/curation_concerns/generic_works_controller_spec.rb'
     remove_file 'spec/actors/curation_concerns/generic_work_actor_spec.rb'
   end
+
+  def copy_fixture_data
+    generate 'curation_concerns:sample_data', '-f'
+  end
 end

--- a/spec/views/curation_concerns/admin/_admin_menu.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/_admin_menu.html.erb_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe "admin_menu.html.erb" do
+  let(:configuration) do
+    {
+      menu: {
+        index: {}
+      }
+    }
+  end
+  before do
+    allow(view).to receive(:action_name).and_return(:index)
+    render partial: "curation_concerns/admin/admin_menu", locals: { configuration: configuration }
+  end
+  context "when there's an item in the index menu" do
+    it "makes a link to the right action" do
+      expect(rendered).to have_link "Admin Dashboard", href: curation_concerns.admin_root_path
+    end
+    it "marks the current page as selected" do
+      expect(rendered).to have_selector "li > a.selected"
+    end
+  end
+end

--- a/spec/views/curation_concerns/admin/_resource_stats.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/_resource_stats.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'curation_concerns/admin/_resource_stats.html.erb', type: :view do
+  before do
+    assign(:resource_stats, resource_stats)
+  end
+  let(:resource_stats) do
+    instance_double(CurationConcerns::ResourceStatisticsSource,
+                    open_concerns_count: 25,
+                    authenticated_concerns_count: 300,
+                    restricted_concerns_count: 777,
+                    expired_embargo_now_authenticated_concerns_count: 66,
+                    expired_embargo_now_open_concerns_count: 77,
+                    active_embargo_now_authenticated_concerns_count: 88,
+                    active_embargo_now_restricted_concerns_count: 99,
+                    expired_lease_now_authenticated_concerns_count: 6666,
+                    expired_lease_now_restricted_concerns_count: 7777,
+                    active_lease_now_authenticated_concerns_count: 8888,
+                    active_lease_now_open_concerns_count: 9999)
+  end
+
+  it "renders without error" do
+    render partial: "curation_concerns/admin/resource_stats", locals: { resource_stats: resource_stats }
+    expect(rendered).to have_content("Open Access25")
+    expect(rendered).to have_content("Institution Name300")
+    expect(rendered).to have_content("Private777")
+    expect(rendered).to have_content("Embargo (Expired, Authenticated)66")
+    expect(rendered).to have_content("Embargo (Expired, Open)77")
+    expect(rendered).to have_content("Embargo (Active, Authenticated)88")
+    expect(rendered).to have_content("Embargo (Active, Restricted)99")
+    expect(rendered).to have_content("Lease (Active, Authenticated)8888")
+    expect(rendered).to have_content("Lease (Active, Open)9999")
+    expect(rendered).to have_content("Lease (Expired, Authenticated)6666")
+    expect(rendered).to have_content("Lease (Expired, Restricted)7777")
+  end
+end

--- a/spec/views/curation_concerns/admin/_total_objects_charts.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/_total_objects_charts.html.erb_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'curation_concerns/admin/_total_objects_charts.html.erb', type: :view do
+  before do
+    assign(:configuration, configuration)
+    allow(view).to receive(:action_name).and_return(:index)
+    allow(CurationConcerns::ResourceStatisticsSource).to receive(:new).and_return(resource_stats)
+    stub_template 'curation_concerns/admin/widgets/_doughnut.html.erb' => 'Mine 1'
+  end
+  let(:resource_stats) do
+    instance_double(CurationConcerns::ResourceStatisticsSource,
+                    open_concerns_count: 25,
+                    authenticated_concerns_count: 300,
+                    restricted_concerns_count: 777,
+                    expired_embargo_now_authenticated_concerns_count: 66,
+                    expired_embargo_now_open_concerns_count: 77,
+                    active_embargo_now_authenticated_concerns_count: 88,
+                    active_embargo_now_restricted_concerns_count: 99,
+                    expired_lease_now_authenticated_concerns_count: 6666,
+                    expired_lease_now_restricted_concerns_count: 7777,
+                    active_lease_now_authenticated_concerns_count: 8888,
+                    active_lease_now_open_concerns_count: 9999)
+  end
+  let(:configuration) do
+    {
+      data_sources: {
+        resource_stats: CurationConcerns::ResourceStatisticsSource
+      }
+    }
+  end
+
+  it "renders without error" do
+    render
+    expect(rendered).to have_content("Mine 1")
+  end
+end

--- a/spec/views/curation_concerns/admin/index.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/index.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'curation_concerns/admin/index.html.erb', type: :view do
+  before do
+    assign(:configuration, configuration)
+    allow(view).to receive(:action_name).and_return(:index)
+    stub_template 'curation_concerns/admin/_my_view_1.html.erb' => 'Mine 1'
+    stub_template 'curation_concerns/admin/_my_view_2.html.erb' => 'Another One'
+  end
+  let(:configuration) do
+    { actions: {
+      index: {
+        partials: [
+          "my_view_1",
+          "my_view_2"
+        ]
+      }
+    } }
+  end
+
+  it "renders all the partials" do
+    render
+    expect(rendered).to have_content("Mine 1")
+    expect(rendered).to have_content("Another One")
+  end
+end

--- a/spec/views/curation_concerns/admin/widgets/_doughnut.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/widgets/_doughnut.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe "_doughnut.html.erb" do
+  let(:data) { { mine: 1, yours: 0 } }
+  before do
+    render "curation_concerns/admin/widgets/doughnut", data: data, label: 'my_pie'
+  end
+
+  it "makes a div with data and class" do
+    expect(rendered).to have_css "div#my_pie-stats-doughnut.stats-doughnut"
+    expect(rendered).to have_selector 'div[data-flot]'
+    expect(rendered).to have_selector 'div[data-label]'
+    text = rendered.to_s
+    expect(text).to include 'data-flot="[{&quot;label&quot;:&quot;mine&quot;,&quot;data&quot;:1},{&quot;label&quot;:&quot;yours&quot;,&quot;data&quot;:0}]"'
+    expect(text).to include 'data-label="my_pie_data"'
+  end
+end

--- a/spec/views/curation_concerns/permissions/confirm.html.erb_spec.rb
+++ b/spec/views/curation_concerns/permissions/confirm.html.erb_spec.rb
@@ -16,7 +16,7 @@ describe 'curation_concerns/permissions/confirm.html.erb' do
   end
 
   context 'when the work is leased' do
-    let(:curation_concern) { build(:leased_work, embargo_date: '2099-09-26'.to_date) }
+    let(:curation_concern) { build(:leased_work, lease_date: '2099-09-26'.to_date) }
 
     it 'has a message about leases' do
       expect(rendered).to have_content "You've applied a lease to this Generic Work, Test title, changing its visibility to Open Access until September 26th, 2099. Would you like to apply the same lease to all of the files within the Generic Work as well?"

--- a/spec/views/shared/_my_actions.html.erb_spec.rb
+++ b/spec/views/shared/_my_actions.html.erb_spec.rb
@@ -18,6 +18,7 @@ describe 'shared/_my_actions.html.erb' do
       expect(rendered).to have_link("My Collections", href: search_path_for_my_collections)
       expect(rendered).to have_link("Embargos", href: embargoes_path)
       expect(rendered).to have_link("Leases", href: leases_path)
+      expect(rendered).to have_link("Admin Dashboard", href: curation_concerns.admin_root_path)
     end
   end
 


### PR DESCRIPTION
Documentation is found in the README, Wiki, and
`CurationConcerns::AdminController`. This enables three widgets:

* Count by Visibility
* Count by Embargo Status
* Table-view of Count by Visibility & Embargo Status

Configuration is done in the CurationConcerns initializer, and looks
like this:

```ruby
{
  menu: {
    index: {},
    resource_details: {}
  },
  actions: {
    index: {
      partials: [
        "total_objects_charts",
        "total_embargo_visibility"
      ]
    },
    resource_details: {
      partials: [
        "total_objects"
      ]
    }
  },
  data_sources: {
    resource_stats: CurationConcerns::ResourceStatisticsSource
  }
}
```