### PR TITLE
Add default translation for dashboard -> menu -> resource_details

### DIFF
--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -166,6 +166,7 @@ en:
     dashboard:
       menu:
         index: "Admin Dashboard"
+        resource_details: "Resource Details"
   blacklight:
     search:
       fields:

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -24,4 +24,11 @@ class TestAppGenerator < Rails::Generators::Base
   def copy_fixture_data
     generate 'curation_concerns:sample_data', '-f'
   end
+
+  def enable_i18n_translation_errors
+    gsub_file "config/environments/development.rb",
+              "# config.action_view.raise_on_missing_translations = true", "config.action_view.raise_on_missing_translations = true"
+    gsub_file "config/environments/test.rb",
+              "# config.action_view.raise_on_missing_translations = true", "config.action_view.raise_on_missing_translations = true"
+  end
 end


### PR DESCRIPTION
Fixes #1015

Adds a default translation for dashboard -> menu -> resource_details
