### PR TITLE
Adding a module that includes items for a controller to act as an admin controller

### DIFF
--- a/app/controllers/concerns/curation_concerns/act_as_admin_controller.rb
+++ b/app/controllers/concerns/curation_concerns/act_as_admin_controller.rb
@@ -1,0 +1,25 @@
+module CurationConcerns
+  # Behavior to allow any controller to be displayed within
+  # the administrative dashboard
+  #
+  # Example useage:
+  #
+  #    module CurationConcerns
+  #      class Admin::MyController < ApplicationController
+  #        include CurationConcerns::ActAsAdminController
+  #
+  #        # do my stuff ...
+  #      end
+  #    end
+  #
+  module ActAsAdminController
+    extend ActiveSupport::Concern
+    included do
+      before_action :load_configuration
+      layout 'admin'
+    end
+    def load_configuration
+      @configuration = CurationConcerns::AdminController.configuration
+    end
+  end
+end

--- a/spec/controllers/curation_concerns/acts_as_admin_controller_spec.rb
+++ b/spec/controllers/curation_concerns/acts_as_admin_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    include CurationConcerns::ActAsAdminController
+
+    def index
+      render 'curation_concerns/admin/index'
+    end
+  end
+  describe "layout" do
+    it "renders admin" do
+      get :index
+      expect(response).to render_template "layouts/admin"
+    end
+  end
+
+  describe "loads_configuration" do
+    subject { controller.load_configuration }
+    it { is_expected.to eq CurationConcerns::AdminController.configuration }
+  end
+end


### PR DESCRIPTION
A few things need to be included for another controller to successfully act as an admin controller.

This PR creates a module for including those things.