### PR TITLE
Removing default since it is not being used and it causes javascript errors in sufia tests

### DIFF
--- a/app/assets/javascripts/curation_concerns/charts.js
+++ b/app/assets/javascripts/curation_concerns/charts.js
@@ -3,7 +3,7 @@
 //= require highcharts/modules/drilldown
 
 (function( $ ){
-  $.fn.pie_chart = function(title = '', data) {
+  $.fn.pie_chart = function(title, data) {
     // Create the chart
     $(this).highcharts({
         chart: {


### PR DESCRIPTION

With master there are 9 javascript failures:
https://travis-ci.org/projecthydra/sufia/jobs/162849488#L2058-L2069

With this branch there are 9 less failures
https://travis-ci.org/projecthydra/sufia/jobs/162856776#L2290

@projecthydra/sufia-code-reviewers
