### PR TITLE
Revert part of d003622. Restore and deprecate include_current_value

### DIFF
--- a/app/helpers/curation_concerns/main_app_helpers.rb
+++ b/app/helpers/curation_concerns/main_app_helpers.rb
@@ -9,4 +9,5 @@ module CurationConcerns::MainAppHelpers
   include CurationConcerns::LeaseHelper
   include CurationConcerns::CollectionsHelper
   include CurationConcerns::ChartsHelper
+  include CurationConcerns::RightsHelper
 end

--- a/app/helpers/curation_concerns/rights_helper.rb
+++ b/app/helpers/curation_concerns/rights_helper.rb
@@ -1,0 +1,13 @@
+module CurationConcerns::RightsHelper
+  extend Deprecation
+  self.deprecation_horizon = 'curation_concerns version 2.0.0'
+
+  def include_current_value(value, _index, render_options, html_options)
+    unless value.blank? || RightsService.active?(value)
+      html_options[:class] << ' force-select'
+      render_options += [[RightsService.label(value), value]]
+    end
+    [render_options, html_options]
+  end
+  deprecation_deprecate include_current_value: 'use LicenseService#include_current_value instead'
+end


### PR DESCRIPTION
This prevents users of older versions of sufia from encountering an undefined method error, and is the proper way to do SemVer.

See d003622