### PR TITLE
Refactor the admin controller to initialize the statistics source

### DIFF
--- a/app/controllers/concerns/curation_concerns/admin_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/admin_controller_behavior.rb
@@ -10,7 +10,8 @@ module CurationConcerns
       layout "admin"
 
       def index
-        render "index"
+        @resource_statistics = @configuration.fetch(:data_sources).fetch(:resource_stats).new
+        render 'index'
       end
     end
 

--- a/app/views/curation_concerns/admin/_total_embargo_visibility.html.erb
+++ b/app/views/curation_concerns/admin/_total_embargo_visibility.html.erb
@@ -1,17 +1,16 @@
-<% resource_stats = @configuration[:data_sources][:resource_stats].new %>
     <h4>Embargos & Leases</h4>
       <%= render "curation_concerns/admin/widgets/pie", label: "embargo",
         data: {
         t("curation_concerns.visibility.embargo.text") => {
-          t("curation_concerns.visibility.embargo.expired.authenticated.text") => resource_stats.expired_embargo_now_authenticated_concerns_count,
-          t("curation_concerns.visibility.embargo.expired.open.text") => resource_stats.expired_embargo_now_open_concerns_count,
-          t("curation_concerns.visibility.embargo.active.authenticated.text") => resource_stats.active_embargo_now_authenticated_concerns_count,
-          t("curation_concerns.visibility.embargo.active.restricted.text") => resource_stats.active_embargo_now_restricted_concerns_count
+          t("curation_concerns.visibility.embargo.expired.authenticated.text") => @resource_statistics.expired_embargo_now_authenticated_concerns_count,
+          t("curation_concerns.visibility.embargo.expired.open.text") => @resource_statistics.expired_embargo_now_open_concerns_count,
+          t("curation_concerns.visibility.embargo.active.authenticated.text") => @resource_statistics.active_embargo_now_authenticated_concerns_count,
+          t("curation_concerns.visibility.embargo.active.restricted.text") => @resource_statistics.active_embargo_now_restricted_concerns_count
         },
         t("curation_concerns.visibility.lease.text") => {
-          t("curation_concerns.visibility.lease.active.authenticated.text") => resource_stats.active_lease_now_authenticated_concerns_count,
-          t("curation_concerns.visibility.lease.expired.restricted.text") => resource_stats.expired_lease_now_restricted_concerns_count,
-          t("curation_concerns.visibility.lease.expired.authenticated.text") => resource_stats.expired_lease_now_authenticated_concerns_count,
-          t("curation_concerns.visibility.lease.active.open.text") => resource_stats.active_lease_now_open_concerns_count,
+          t("curation_concerns.visibility.lease.active.authenticated.text") => @resource_statistics.active_lease_now_authenticated_concerns_count,
+          t("curation_concerns.visibility.lease.expired.restricted.text") => @resource_statistics.expired_lease_now_restricted_concerns_count,
+          t("curation_concerns.visibility.lease.expired.authenticated.text") => @resource_statistics.expired_lease_now_authenticated_concerns_count,
+          t("curation_concerns.visibility.lease.active.open.text") => @resource_statistics.active_lease_now_open_concerns_count,
         }
       }  %>

--- a/app/views/curation_concerns/admin/_total_objects.html.erb
+++ b/app/views/curation_concerns/admin/_total_objects.html.erb
@@ -1,2 +1,1 @@
-<% resource_stats = @configuration[:data_sources][:resource_stats].new %>
-<%= render "resource_stats", resource_stats: resource_stats %>
+<%= render "resource_stats", resource_stats: @resource_statistics %>

--- a/app/views/curation_concerns/admin/_total_objects_charts.html.erb
+++ b/app/views/curation_concerns/admin/_total_objects_charts.html.erb
@@ -1,8 +1,7 @@
-<% resource_stats = @configuration[:data_sources][:resource_stats].new %>
     <h4>Visibility</h4>
       <%= render "curation_concerns/admin/widgets/pie", label: "visibility",
               data: {
-                  t("curation_concerns.visibility.open.text") => resource_stats.open_concerns_count,
-                  t("curation_concerns.visibility.authenticated.text") => resource_stats.authenticated_concerns_count,
-                  t("curation_concerns.visibility.restricted.text") =>  resource_stats.restricted_concerns_count
+                  t("curation_concerns.visibility.open.text") => @resource_statistics.open_concerns_count,
+                  t("curation_concerns.visibility.authenticated.text") => @resource_statistics.authenticated_concerns_count,
+                  t("curation_concerns.visibility.restricted.text") =>  @resource_statistics.restricted_concerns_count
               } %>

--- a/spec/controllers/curation_concerns/admin_controller_spec.rb
+++ b/spec/controllers/curation_concerns/admin_controller_spec.rb
@@ -2,17 +2,20 @@ require 'spec_helper'
 
 RSpec.describe CurationConcerns::AdminController do
   routes { CurationConcerns::Engine.routes }
+
   describe "GET /admin" do
     context "when you have permission" do
-      let(:user) { FactoryGirl.create(:admin) }
       before do
         allow(controller).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
       end
+
       it "works" do
         get :index
         expect(response).to be_success
+        expect(assigns[:resource_statistics]).to be_kind_of CurationConcerns::ResourceStatisticsSource
       end
     end
+
     context "when they don't have permission" do
       it "throws a CanCan error" do
         get :index

--- a/spec/views/curation_concerns/admin/_resource_stats.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/_resource_stats.html.erb_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe 'curation_concerns/admin/_resource_stats.html.erb', type: :view do
-  before do
-    assign(:resource_stats, resource_stats)
-  end
   let(:resource_stats) do
     instance_double(CurationConcerns::ResourceStatisticsSource,
                     open_concerns_count: 25,

--- a/spec/views/curation_concerns/admin/_total_objects_charts.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/_total_objects_charts.html.erb_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 describe 'curation_concerns/admin/_total_objects_charts.html.erb', type: :view do
   before do
-    assign(:configuration, configuration)
     allow(view).to receive(:action_name).and_return(:index)
-    allow(CurationConcerns::ResourceStatisticsSource).to receive(:new).and_return(resource_stats)
+    assign(:resource_statistics, resource_stats)
     stub_template 'curation_concerns/admin/widgets/_pie.html.erb' => 'Mine 1'
   end
   let(:resource_stats) do
@@ -20,13 +19,6 @@ describe 'curation_concerns/admin/_total_objects_charts.html.erb', type: :view d
                     expired_lease_now_restricted_concerns_count: 7777,
                     active_lease_now_authenticated_concerns_count: 8888,
                     active_lease_now_open_concerns_count: 9999)
-  end
-  let(:configuration) do
-    {
-      data_sources: {
-        resource_stats: CurationConcerns::ResourceStatisticsSource
-      }
-    }
   end
 
   it "renders without error" do


### PR DESCRIPTION
This keeps multiple views from having to be aware of the structure of a
nested hash.