### PR TITLE
Make assign_visibility work with symbol hash keys

### DIFF
--- a/app/actors/curation_concerns/actors/file_set_actor.rb
+++ b/app/actors/curation_concerns/actors/file_set_actor.rb
@@ -125,7 +125,7 @@ module CurationConcerns
         end
 
         def assign_visibility?(file_set_params = {})
-          !((file_set_params || {}).keys & %w(visibility embargo_release_date lease_expiration_date)).empty?
+          !(file_set_params.keys.map(&:to_s) & %w(visibility embargo_release_date lease_expiration_date)).empty?
         end
 
         # copy visibility from source_concern to destination_concern

--- a/spec/actors/curation_concerns/file_set_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_set_actor_spec.rb
@@ -207,6 +207,30 @@ describe CurationConcerns::Actors::FileSetActor do
     end
   end
 
+  describe "#assign_visibility?" do
+    context "when no params are specified" do
+      it "does not need to assign visibility" do
+        expect(actor.send(:assign_visibility?)).to eq false
+      end
+    end
+
+    context "when file set params with visibility are specified with symbols as keys" do
+      let(:file_set_params) { { visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
+
+      it "does need to assign visibility" do
+        expect(actor.send(:assign_visibility?, file_set_params)).to eq true
+      end
+    end
+
+    context "when file set params with visibility are specified with strings as keys" do
+      let(:file_set_params) { { "visibility" => Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC } }
+
+      it "does need to assign visibility" do
+        expect(actor.send(:assign_visibility?, file_set_params)).to eq true
+      end
+    end
+  end
+
   describe "#set_representative" do
     let!(:work) { build(:generic_work, representative: rep) }
     let!(:file_set) { build(:file_set) }


### PR DESCRIPTION
`create_metadata` may ignore file_set_params

I would expect to be able to set the visibility of a file_set as followes
```ruby
ds_actor = CurationConcerns::Actors::FileSetActor.new(file_set, user)
ds_actor.create_metadata(obj, {visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE})
```

However, because the hash keys are compared as strings in the private method `assign_visibility`, this example fails to match and thus visibility is always inherited from the parent rather than assigned.  Initially, I considered changing the comparison to just compare symbols, `%i{}` but there are other tests that fail because there are other occasions where hash keys are passed as Strings.

Changes proposed in this pull request:
* allow `assign_visibility` and thus `create_metadata` to accept both strings and symbols as hash keys.

@projecthydra/sufia-code-reviewers

