### PR TITLE
more forgiving call for label from QaSelectService

### DIFF
--- a/app/services/curation_concerns/qa_select_service.rb
+++ b/app/services/curation_concerns/qa_select_service.rb
@@ -23,7 +23,7 @@ module CurationConcerns
     end
 
     def label(id)
-      authority.find(id).fetch('term')
+      authority.find(id)['term']
     end
 
     def active_elements


### PR DESCRIPTION
more forgiving call for label from QaSelectService returns nil instead of throwing exception

What I did: Migrated (customized) metadata from Hydranorth application based on Sufia 6.2 to Sufia 7.2 application.  All ```catalog``` calls failed in the new application.

```
Rendered /usr/lib64/ruby/gems/2.3.0/gems/sufia-7.2.0/app/views/catalog/_docume
nt.html.erb (53.2ms)
  Rendered curation_concerns/generic_works/_generic_work.html.erb (618.9ms)
  Rendered /usr/lib64/ruby/gems/2.3.0/gems/blacklight-6.7.1/app/views/catalog/_s
earch_results.html.erb (746.1ms)
  Rendered /usr/lib64/ruby/gems/2.3.0/gems/sufia-7.2.0/app/views/catalog/index.h
tml.erb within layouts/curation_concerns/1_column (897.9ms)
Completed 500 Internal Server Error in 1395ms (ActiveRecord: 29.6ms)

KeyError - key not found: "term":
  curation_concerns (1.6.2) app/services/curation_concerns/qa_select_service.rb:
27:in `label'
  sufia (7.2.0) app/helpers/sufia/sufia_helper_behavior.rb:175:in `block in lice
nse_links'
  sufia (7.2.0) app/helpers/sufia/sufia_helper_behavior.rb:175:in `license_links
'
```

Discovered that ```fetch``` will throw the KeyError exception while the ```[]``` syntax will return nil and carry on when the key value is not present.

@projecthydra/sufia-code-reviewers