### PR TITLE
Adding LicenseService dependency injection

### DIFF
--- a/app/renderers/curation_concerns/renderers/rights_attribute_renderer.rb
+++ b/app/renderers/curation_concerns/renderers/rights_attribute_renderer.rb
@@ -19,7 +19,7 @@ module CurationConcerns
           if parsed_uri.nil?
             ERB::Util.h(value)
           else
-            %(<a href=#{ERB::Util.h(value)} target="_blank">#{CurationConcerns::LicenseService.new.label(value)}</a>)
+            %(<a href=#{ERB::Util.h(value)} target="_blank">#{CurationConcerns.config.license_service_class.new.label(value)}</a>)
           end
         end
     end

--- a/app/services/rights_service.rb
+++ b/app/services/rights_service.rb
@@ -9,7 +9,7 @@ module RightsService
   end
 
   def self.select_all_options
-    Deprecation.warn(RightsService, "RightsService is deprecated. Use CurationConcerns::LicenseService instead. This will be removed in curation_concerns 2.0")
+    Deprecation.warn(RightsService, "RightsService is deprecated. Use CurationConcerns.config.license_service_class instead. This will be removed in curation_concerns 2.0")
     authority.all.map do |element|
       [element[:label], element[:id]]
     end

--- a/app/views/curation_concerns/base/_form_rights.html.erb
+++ b/app/views/curation_concerns/base/_form_rights.html.erb
@@ -9,7 +9,7 @@
         <a href="http://creativecommons.org/licenses/" target="_blank">Here's some help</a> if you don't know which license to choose.
       </p>
 
-      <% license_service = CurationConcerns::LicenseService.new %>
+      <% license_service = CurationConcerns.config.license_service_class.new %>
       <%= f.input :rights, as: :multi_value_select,
         collection: license_service.select_active_options,
         include_blank: true,

--- a/lib/curation_concerns/configuration.rb
+++ b/lib/curation_concerns/configuration.rb
@@ -221,6 +221,18 @@ module CurationConcerns
       registered_curation_concern_types.map(&:constantize)
     end
 
+    # A configuration point for changing the behavior of the license service.
+    #
+    # @!attribute [w] license_service_class
+    #   A configuration point for changing the behavior of the license service.
+    #
+    #   @see CurationConcerns::LicenseService for implementation details
+    #   @see https://github.com/projecthydra/curation_concerns/pull/1047
+    attr_writer :license_service_class
+    def license_service_class
+      @license_service_class ||= CurationConcerns::LicenseService
+    end
+
     private
 
       # @param [Symbol] the symbol representing the model


### PR DESCRIPTION
Adding LicenseService dependency injection

Building on the request of @pgwillia on #1047, I'm exposing a means of
leveraging a different license service class. This is useful as some
places allow the user to free-form fill out a license; While I'm not
sure of the general usage, this is a demonstration of how it might be
done.