### PR TITLE
Change when AF::Noid 2.0 is required so it doesn't break in production mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - RAILS_VERSION=4.2.7
+    - RAILS_VERSION=4.2.7.1
       RDF_VERSION=1.99.1
-    - RAILS_VERSION=5.0.0
+    - RAILS_VERSION=5.0.0.1
       RDF_VERSION=2.1.0
 notifications:
   irc:

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kaminari_route_prefix', '~> 0.0.1'
   spec.add_dependency 'active_attr'
   spec.add_dependency 'hydra-works', '>= 0.14.0'
-  spec.add_dependency 'active_fedora-noid', '~> 2.0.0.beta1'
+  spec.add_dependency 'active_fedora-noid', '~> 2.0.0.beta5'
   spec.add_dependency 'qa', '~> 0.5'
   spec.add_dependency 'redlock', '~> 0.1.2'
   spec.add_dependency 'solrizer', '~> 3.4'

--- a/lib/curation_concerns.rb
+++ b/lib/curation_concerns.rb
@@ -1,3 +1,4 @@
+require 'active_fedora/noid'
 require 'curation_concerns/version'
 require 'curation_concerns/engine'
 require 'curation_concerns/configuration'

--- a/lib/curation_concerns/engine.rb
+++ b/lib/curation_concerns/engine.rb
@@ -34,7 +34,6 @@ module CurationConcerns
     end
 
     initializer 'requires' do
-      require 'active_fedora/noid'
       require 'curation_concerns/noid'
       require 'curation_concerns/permissions'
       require 'curation_concerns/lockable'


### PR DESCRIPTION
 Automatically run the new AF::Noid generator to complete installation of AF::Noid.

**DO NOT MERGE** until the PR points at a released version of AF::Noid (pointing at a GitHub branch at the moment).

@projecthydra/sufia-code-reviewers

