### PR TITLE
No turbolinks downloads backport

### DIFF
--- a/app/views/collections/_media_display.html.erb
+++ b/app/views/collections/_media_display.html.erb
@@ -1,1 +1,1 @@
-<a href="<%= collection_path %>" target="_new"><img src="Other.png" alt="No preview available" width="338" /></a>
+<a href="<%= collection_path %>" target="_new" data-turbolinks="false"><img src="Other.png" alt="No preview available" width="338" /></a>

--- a/app/views/collections/_media_display.html.erb
+++ b/app/views/collections/_media_display.html.erb
@@ -1,1 +1,1 @@
-<a href="<%= collection_path %>" target="_new" data-turbolinks="false"><img src="Other.png" alt="No preview available" width="338" /></a>
+<a href="<%= collection_path %>" target="_blank" data-turbolinks="false"><img src="Other.png" alt="No preview available" width="338" /></a>

--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -1,5 +1,5 @@
   <div class="form-actions">
-    <%= link_to "Download this File", main_app.download_path(presenter), class: 'btn btn-default' %>
+    <%= link_to "Download this File", main_app.download_path(presenter), class: 'btn btn-default', data: { turbolinks: false } %>
     <% if can? :edit, presenter.id %>
       <%= link_to "Edit this File", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default'  %>
     <% end %>

--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -1,5 +1,5 @@
   <div class="form-actions">
-    <%= link_to "Download this File", main_app.download_path(presenter), class: 'btn btn-default', data: { turbolinks: false } %>
+    <%= link_to "Download this File", main_app.download_path(presenter), class: 'btn btn-default', data: { turbolinks: false }, target: :_blank %>
     <% if can? :edit, presenter.id %>
       <%= link_to "Edit this File", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default'  %>
     <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -7,6 +7,7 @@
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
                   target: "_new",
+                  data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.default_link') %>
       <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -6,7 +6,7 @@
                     alt: "",
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
-                  target: "_new",
+                  target: :_blank,
                   data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.default_link') %>

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -7,6 +7,7 @@
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
                   target: "_new",
+                  data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.image_link') %>
       <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -6,7 +6,7 @@
                     alt: "",
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
-                  target: "_new",
+                  target: :_blank,
                   data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.image_link') %>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -7,6 +7,7 @@
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
                   target: "_new",
+                  data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.office_link') %>
       <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -8,6 +8,7 @@
       <%= link_to main_app.download_path(file_set),
                   target: "_new",
                   data: { turbolinks: false },
+                  target: :_blank,
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.office_link') %>
       <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -7,6 +7,7 @@
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
                   target: "_new",
+                  data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.pdf_link') %>
       <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -6,7 +6,7 @@
                     alt: "",
                     role: "presentation" %>
       <%= link_to main_app.download_path(file_set),
-                  target: "_new",
+                  target: :_blank,
                   data: { turbolinks: false },
                   class: "btn btn-default" do %>
           <%= t('curation_concerns.show.downloadable_content.pdf_link') %>

--- a/app/views/curation_concerns/single_use_links_viewer/show.html.erb
+++ b/app/views/curation_concerns/single_use_links_viewer/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="lower"><%= @presenter %></h1>
     <h2 class="non lower">Actions</h2>
     <p>
-      <%= link_to "Download (can only be used once)", @download_link, target: '_blank', data: { 'no-turbolink' => ''} %>
+      <%= link_to "Download (can only be used once)", @download_link, target: :_blank, data: { turbolinks: false } %>
     </p>
   <h2> Descriptions:</h2>
 

--- a/spec/views/single_use_links_viewer/show.html.erb_spec.rb
+++ b/spec/views/single_use_links_viewer/show.html.erb_spec.rb
@@ -27,6 +27,6 @@ describe 'curation_concerns/single_use_links_viewer/show.html.erb' do
   end
 
   it "has turbolinks disabled in the download link" do
-    expect(rendered).to have_selector "a[data-no-turbolink][href^='/single_use_link/download/']"
+    expect(rendered).to have_selector "a[data-turbolinks^='false'][href^='/single_use_link/download/']"
   end
 end


### PR DESCRIPTION
Backports #1063, addressing #1050 for this branch.

> Turbolinks causes xhr requests on local links. For file downloads, this causes browsers to render the contents as text, instead of playing media or displaying the PDF in a viewer. This disables it for the download links.
>Related proposed changes:
> - Replace href target "_new" with "_blank". Since _new is not a valid browsing context name in HTML, clients may ignore it. Before disabling turbolinks explicitly, this caused the bad rendering behavior described above in those clients. (44e47e2)
> - Make download _blank behavior consistent across file download links. (5f8fe1b)
> - Update existing data-no-turbolink calls to the Turbolinks 5 syntax. (2e9a794)

I considered only backporting the first commit, but decided it would be easier to make additional changes to these files if they were kept in sync; and that any (very small) risk of unexpected behavior changes on the 1.6-stable release series was outweighed by this consideration.

@projecthydra/sufia-code-reviewers
