### PR TITLE
Adds inspect_work endpoint for registered work types

### DIFF
--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -19,7 +19,7 @@ module CurationConcerns
 
     module ClassMethods
       def curation_concern_type=(curation_concern_type)
-        load_and_authorize_resource class: curation_concern_type, instance_name: :curation_concern, except: [:show, :file_manager]
+        load_and_authorize_resource class: curation_concern_type, instance_name: :curation_concern, except: [:show, :file_manager, :inspect_work]
         self._curation_concern_type = curation_concern_type
       end
 
@@ -102,6 +102,11 @@ module CurationConcerns
     end
 
     def file_manager
+      presenter
+    end
+
+    def inspect_work
+      raise Hydra::AccessDenied unless current_ability.admin?
       presenter
     end
 

--- a/app/presenters/curation_concerns/inspect_work_presenter.rb
+++ b/app/presenters/curation_concerns/inspect_work_presenter.rb
@@ -1,0 +1,52 @@
+module CurationConcerns
+  class InspectWorkPresenter
+    def initialize(solr_document, current_ability)
+      @solr_document = solr_document
+      @current_ability = current_ability
+    end
+    attr_reader :solr_document, :current_ability
+
+    def workflow
+      return { comments: [], roles: [] } unless sipity_entity
+      {
+        entity_id: sipity_entity.id,
+        proxy_for: sipity_entity.proxy_for_global_id,
+        workflow_id: sipity_entity.workflow_id,
+        workflow_name: sipity_entity.workflow_name,
+        state_id: sipity_entity.workflow_state_id,
+        state_name: sipity_entity.workflow_state_name,
+        comments: workflow_comments,
+        roles: sipity_entity_roles
+      }
+    end
+
+    def solr
+      @solr_document.inspect
+    end
+
+    private
+
+      def sipity_entity
+        @sipity_entity ||= PowerConverter.convert(solr_document, to: :sipity_entity)
+      end
+
+      def sipity_entity_roles
+        roles = CurationConcerns::Workflow::PermissionQuery.scope_roles_associated_with_the_given_entity(entity: solr_document)
+        roles.map do |role|
+          { id: role.id, name: role.name, description: role.description, users: sipity_entity_role_users(role) }
+        end
+      end
+
+      def sipity_entity_role_users(role)
+        users = CurationConcerns::Workflow::PermissionQuery.scope_users_for_entity_and_roles(entity: sipity_entity, roles: role)
+        users.map(&:user_key)
+      end
+
+      def workflow_comments
+        return [] unless sipity_entity && sipity_entity.comments.count > 0
+        sipity_entity.comments.map do |comment|
+          { comment: comment.comment, created_at: comment.created_at }
+        end
+      end
+  end
+end

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -50,6 +50,10 @@ module CurationConcerns
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)
     end
 
+    def inspect_work
+      @inspect_workflow ||= InspectWorkPresenter.new(solr_document, current_ability)
+    end
+
     # @return FileSetPresenter presenter for the representative FileSets
     def representative_presenter
       return nil if representative_id.blank?

--- a/app/views/curation_concerns/base/inspect_work.html.erb
+++ b/app/views/curation_concerns/base/inspect_work.html.erb
@@ -1,0 +1,37 @@
+<h1><%= t("inspect_work.link_text") %></h1>
+<ul class="breadcrumb">
+  <li>
+    Back to <%= link_to @presenter.to_s, [main_app, @presenter] %>
+  </li>
+</ul>
+
+<h3>Workflow</h3>
+<dl>
+  <% workflow = @presenter.inspect_work.workflow %>
+  <dt>Object Name</dt>
+  <dd><%= @presenter.to_s %></dd>
+  <dt>Processing Entity ID</dt>
+  <dd>Entity ID: <%= workflow[:entity_id] %> (Proxy for <%= workflow[:proxy_for] %>)</dd>
+  <dt>Workflow</dt>
+  <dd>Name: <%= workflow[:workflow_name] %> (ID=<%= workflow[:workflow_id] %>)</dd>
+  <dt>State</dt>
+  <dd>State Name: <%= workflow[:state_name] %> (ID=<%= workflow[:state_id] %>)</dd>
+  <dt>Workflow Comments</dt>
+  <dd>
+    <% workflow[:comments].each do |comment| %>
+        <dd><%= comment[:created_at] %>, <%= comment[:comment] %></dd>
+    <% end %>
+  </dd>
+  <dt>Roles</dt>
+  <dd>
+    <% workflow[:roles].each do |role| %>
+      <dd><%= role[:name] %> (ID=<%= role[:id] %>) <%= role[:description] %> Users: <%= role[:users] %></dd>
+  <% end %>
+  </dd>
+</dl>
+
+<h3>Persistence</h3>
+<dl>
+  <dt>Solr</dt>
+  <dd><%= @presenter.inspect_work.solr %></dd>
+</dl>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -233,6 +233,8 @@ en:
     submit:
       sipity_workflow_responsibility:
         create: "Add"
+  inspect_work:
+        link_text: 'Inspect Work'
   simple_form:
     required:
       html: '<span class="label label-info required-tag">required</span>'

--- a/lib/curation_concerns/rails/routes.rb
+++ b/lib/curation_concerns/rails/routes.rb
@@ -16,6 +16,7 @@ module ActionDispatch::Routing
           namespaced_resources curation_concern_name, only: [] do
             member do
               get :file_manager
+              get :inspect_work
             end
           end
         end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -293,4 +293,16 @@ describe CurationConcerns::GenericWorksController do
       expect(assigns(:presenter)).not_to be_blank
     end
   end
+
+  describe '#inspect_work' do
+    let(:work) { create(:private_generic_work, user: user) }
+    context 'when I am a repository manager' do
+      before { allow_any_instance_of(User).to receive(:groups).and_return(['admin']) }
+      it "the response is successful" do
+        get :inspect_work, params: { id: work.id }
+        expect(response).to be_success
+        expect(assigns(:presenter)).not_to be_blank
+      end
+    end
+  end
 end

--- a/spec/presenters/curation_concerns/inspect_work_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/inspect_work_presenter_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe CurationConcerns::InspectWorkPresenter, no_clean: true do
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:attributes) do
+    { "id" => '888888',
+      "has_model_ssim" => ["GenericWork"] }
+  end
+
+  let(:user) { create(:user) }
+  let(:ability) { Ability.new(user) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+  let(:entity) { instance_double(Sipity::Entity) }
+
+  describe "#workflow" do
+    let(:comments) do
+      { comment: 'comment', created_at: 'unknown' }
+    end
+    let(:roles) do
+      { id: '1', name: 'reviewing', users: ['user1', 'user2'] }
+    end
+    before do
+      allow(entity).to receive(:id).and_return('1')
+      allow(entity).to receive(:workflow_name).and_return('generic_workflow')
+      allow(entity).to receive(:workflow_id).and_return('1')
+      allow(entity).to receive(:proxy_for_global_id).and_return(attributes["id"])
+      allow(entity).to receive(:workflow_id).and_return('1')
+      allow(entity).to receive(:workflow_state_id).and_return('1')
+      allow(entity).to receive(:workflow_state_name).and_return('completed')
+      allow(presenter).to receive(:sipity_entity).and_return(entity)
+      allow(presenter).to receive(:workflow_comments).and_return(comments)
+      allow(presenter).to receive(:sipity_entity_roles).and_return(roles)
+    end
+
+    context "when a valid sipity_entity with workflow exists" do
+      subject { presenter.workflow }
+      it 'returns a hash of workflow related values for ispection' do
+        expect(subject[:entity_id]).to eq '1'
+        expect(subject[:workflow_name]).to eq 'generic_workflow'
+        expect(subject[:workflow_id]).to eq '1'
+        expect(subject[:proxy_for]).to eq attributes["id"]
+        expect(subject[:state_id]).to eq '1'
+        expect(subject[:state_name]).to eq 'completed'
+        expect(subject[:comments][:comment]).to eq 'comment'
+        expect(subject[:roles][:id]).to eq '1'
+        expect(subject[:roles][:name]).to eq 'reviewing'
+        expect(subject[:roles][:users][0]).to eq 'user1'
+      end
+    end
+
+    context "when no sipity_entity with workflow exists" do
+      let(:invalid) { described_class.new('no_solr_document', ability) }
+      it "raises PowerConverter::ConversionError" do
+        expect { invalid.workflow }.to raise_exception(PowerConverter::ConversionError)
+      end
+    end
+  end
+end

--- a/spec/presenters/curation_concerns/work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/work_show_presenter_spec.rb
@@ -188,6 +188,15 @@ describe CurationConcerns::WorkShowPresenter do
     end
   end
 
+  context "with inspect_work" do
+    let(:user) { create(:user) }
+    let(:ability) { Ability.new(user) }
+    describe "#inspect_work" do
+      subject { presenter.inspect_work }
+      it { is_expected.to be_kind_of CurationConcerns::InspectWorkPresenter }
+    end
+  end
+
   describe "graph export methods" do
     let(:graph) do
       RDF::Graph.new.tap do |g|

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -39,6 +39,10 @@ describe 'Routes', type: :routing do
     it 'routes to file_manager' do
       expect(get: 'concern/generic_works/6/file_manager').to route_to(controller: 'curation_concerns/generic_works', action: 'file_manager', id: '6')
     end
+
+    it 'routes to inspect_work' do
+      expect(get: 'concern/generic_works/6/inspect_work').to route_to(controller: 'curation_concerns/generic_works', action: 'inspect_work', id: '6')
+    end
   end
 
   describe 'Permissions' do


### PR DESCRIPTION
Fixes #1026 

This change adds the ability to request a raw debug view of the underlying workflow states for a work. Such a view bypasses logic interpreting workflows in other views, which could be misleading if troubleshooting a related feature. It is also generally useful to see the state of things without resorting to browsing objects in the console.

It is also more generally useful than for just workflows, as any aspect of a work can be tapped into for raw inspection by following the patterns in the presenter.

The name `inspect_work` was chosen over `debug` since you might not be trying to fix a problem, and `inspect` was avoided to differentiate from the Ruby object `inspect` methods. 

Changes proposed in this pull request:
- A new route to `concern/(work_type)/:id/inspect_work` for works based on registered work types
- Corresponding controller action, presenter, and view to handle the request
- A new key in i18n in default locale for basic translations in the view

@projecthydra/sufia-code-reviewers
