### PR TITLE
Render the unavailable template if user cannot act on a work in current workflow state

### DIFF
--- a/app/search_builders/curation_concerns/filter_suppressed_with_roles.rb
+++ b/app/search_builders/curation_concerns/filter_suppressed_with_roles.rb
@@ -9,8 +9,10 @@ module CurationConcerns
     extend ActiveSupport::Concern
     include CurationConcerns::FilterSuppressed
 
+    # Skip the filter if the current user is permitted to take
+    # workflow actions on the work corresponding to the SolrDocument
+    # with id = `blacklight_params[:id]`
     def only_active_works(solr_parameters)
-      # Do not filter works if current user is permitted to take workflow actions
       return if user_has_active_workflow_role?
       super
     end

--- a/app/views/curation_concerns/base/unavailable.html.erb
+++ b/app/views/curation_concerns/base/unavailable.html.erb
@@ -1,0 +1,10 @@
+<h1><%= @presenter %> </h1>
+<span class="state state-<%= @presenter.workflow.state %>"><%= @presenter.workflow.state_label %></span>
+<% if @parent_presenter %>
+    <ul class="breadcrumb">
+        <li><%= link_to @parent_presenter, polymorphic_path([main_app, @parent_presenter]) %></li>
+        <li class="active"><%= @presenter.human_readable_type %></li>
+    </ul>
+<% else %>
+    <span class="human_readable_type">(<%= @presenter.human_readable_type %>)</span>
+<% end %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -181,6 +181,7 @@ en:
     workflow:
       default:
         deposit: "Deposit"
+      unauthorized: "The work is not currently available because it has not yet completed the approval process"
   blacklight:
     search:
       fields:

--- a/lib/curation_concerns/workflow_authorization_exception.rb
+++ b/lib/curation_concerns/workflow_authorization_exception.rb
@@ -1,0 +1,4 @@
+module CurationConcerns
+  class WorkflowAuthorizationException < StandardError
+  end
+end

--- a/spec/views/curation_concerns/base/unavailable.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/unavailable.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'curation_concerns/base/unavailable.html.erb', type: :view do
+  let(:model) do
+    double('model',
+           persisted?: true,
+           to_param: '123',
+           model_name: GenericWork.model_name)
+  end
+  let(:workflow) do
+    double('workflow', state: 'deposited', state_label: 'really deposited')
+  end
+  let(:presenter) do
+    double('presenter',
+           to_s: 'super cool',
+           workflow: workflow,
+           human_readable_type: 'Generic Work')
+  end
+  let(:parent_presenter) do
+    double('parent_presenter',
+           to_s: 'parental remark',
+           to_model: model,
+           human_readable_type: 'Foo Bar')
+  end
+  before do
+    assign(:presenter, presenter)
+    assign(:parent_presenter, parent_presenter)
+    stub_template 'shared/_brand_bar.html.erb' => ''
+    stub_template 'shared/_title_bar.html.erb' => ''
+    flash[:notice] = I18n.t("curation_concerns.workflow.unauthorized")
+    render template: 'curation_concerns/base/unavailable.html.erb', layout: 'layouts/curation_concerns'
+  end
+  it "renders with the flash message" do
+    expect(rendered).to have_content 'super cool'
+    expect(rendered).to have_content 'really deposited'
+    expect(rendered).to have_content 'parental remark'
+    expect(rendered).to have_content 'Generic Work'
+    expect(rendered).to have_content 'The work is not currently available because it has not yet completed the approval process'
+  end
+end


### PR DESCRIPTION
Fixes projecthydra/sufia#2727

