### PR TITLE
url_for_document should return a routable entity, not a string

### DIFF
--- a/app/helpers/curation_concerns/url_helper.rb
+++ b/app/helpers/curation_concerns/url_helper.rb
@@ -3,11 +3,8 @@ module CurationConcerns
     # override Blacklight so we can use our 'curation_concern' namespace
     # We may also pass in a ActiveFedora document instead of a SolrDocument
     def url_for_document(doc, _options = {})
-      if doc.collection?
-        doc
-      else
-        polymorphic_path([main_app, doc])
-      end
+      return doc if doc.collection?
+      [main_app, doc]
     end
 
     # generated models get registered as curation concerns and need a

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 
 describe CurationConcerns::UrlHelper do
-  let(:profile) { ["{}"] }
-  let(:work) { create(:generic_work) }
-  let(:document) { SolrDocument.new(work.to_solr) }
-  subject { helper.url_for_document document }
+  subject { helper.url_for_document(document) }
 
-  it { is_expected.to eq "/concern/generic_works/#{work.id}" }
-
-  it 'uses the curation_concern namespace' do
-    expect(helper.url_for_document(document)).to eq "/concern/generic_works/#{work.id}"
+  context 'when document is a SolrDocument that points at a Work' do
+    let(:work) { create(:generic_work) }
+    let(:document) { SolrDocument.new(work.to_solr) }
+    it "forms the correct path" do
+      expect(polymorphic_path(subject)).to eq "/concern/generic_works/#{work.id}"
+    end
   end
 
   context 'when document is a FileSet' do
-    let(:file) { create(:file_set) }
-    subject { helper.url_for_document file }
-    it { is_expected.to eq "/concern/file_sets/#{file.id}" }
+    let(:document) { create(:file_set) }
+    it "forms the correct path" do
+      expect(polymorphic_path(subject)).to eq "/concern/file_sets/#{document.id}"
+    end
   end
 end


### PR DESCRIPTION
So that the value of url_for_document can be passed to polymorphic_url
as seen here:
https://github.com/projectblacklight/blacklight/blob/e7d7cb883e4d24a5263797cac47a8e5fd5b603ca/app/views/catalog/_document.rss.builder#L3