### PR TITLE
Remove the hint for file uploads

### DIFF
--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -221,7 +221,6 @@ en:
     hints:
       defaults:
         description: 'Please keep your description to 300 words or fewer.'
-        files:       'A PDF is preferred.'
     labels:
       defaults:
         lease_expiration_date:     'until'


### PR DESCRIPTION
This suggests that we prefer a PDF, which is sometimes wrong.
Fixes https://github.com/projecthydra/sufia/issues/2765