### PR TITLE
Create 0-step default workflow. Fixes #1035.

### DIFF
--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -123,13 +123,13 @@ en:
         expires: Expires
         actions: Actions
         no_links: No links have been generated
-      download: 
+      download:
         type: Download
         generate: Generate Download Link
-      show: 
+      show:
         type: Show
         generate: Generate Show Link
-      copy: 
+      copy:
         tooltip: Copied!
         button: Copy to Clipboard
       delete: Delete
@@ -179,15 +179,8 @@ en:
         text: "Private"
         class: "label-danger"
     workflow:
-      generic_work:
-        finalize_digitization: "Finalize Digitization"
-        finalize_metadata: "Finalize Metadata"
-        final_review: "Final Review"
-        complete: "Complete"
-        takedown: "Takedown"
-        flag: "Flag"
-        restore: "Restore"
-        unflag: "Remove Flag"
+      default:
+        deposit: "Deposit"
   blacklight:
     search:
       fields:

--- a/lib/generators/curation_concerns/templates/workflow.json.erb
+++ b/lib/generators/curation_concerns/templates/workflow.json.erb
@@ -1,58 +1,19 @@
 {
-  "workflows": [
-    {
-      "name": "default",
-      "label": "Digital collections workflow",
-      "description": "A multi-step workflow for digital collections",
-      "actions": [
-         {
-           "name": "deposit",
-           "from_states": [],
-           "transition_to": "pending"
-         },
-         {
-           "name": "finalize_digitization",
-           "from_states": [{"names": ["pending"], "roles": ["reviewing"]}],
-           "transition_to": "metadata_review",
-           "attributes": {
-             "presentation_sequence": 1
-           }
-         }, {
-           "name": "finalize_metadata",
-           "from_states": [{"names": ["metadata_review"], "roles": ["finalizing"]}],
-           "transition_to": "final_review",
-           "attributes": {
-           	"presentation_sequence": 2
-           }
-         }, {
-           "name": "complete",
-           "from_states": [{"names": ["final_review"], "roles": ["completing"]}],
-           "transition_to": "complete",
-           "attributes": {
-             "presentation_sequence": 3
-           },
-           "notifications": [],
-           "methods": [
-             "CurationConcerns::Workflow::ActivateObject"
-           ]
-         }, {
-           "name": "takedown",
-           "from_states": [{"names": ["complete"], "roles": ["taking_down"]}],
-           "transition_to": "takedown"
-         }, {
-           "name": "restore",
-           "from_states": [{"names": ["takedown"], "roles": ["restoring"]}],
-           "transition_to": "complete"
-         }, {
-           "name": "flag",
-           "from_states": [{"names": ["complete"], "roles": ["flagging"]}],
-           "transition_to": "flag"
-         }, {
-           "name": "unflag",
-           "from_states": [{"names":["flag"], "roles":["unflagging"]}],
-           "transition_to": "complete"
-         }
-      ]
-    }
-  ]
+    "workflows": [
+        {
+            "name": "default",
+            "label": "Default workflow",
+            "description": "A single submission step, default workflow",
+            "actions": [
+                {
+                    "name": "deposit",
+                    "from_states": [],
+                    "transition_to": "deposited",
+                    "methods": [
+                        "CurationConcerns::Workflow::ActivateObject"
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/spec/features/workflow_roles_spec.rb
+++ b/spec/features/workflow_roles_spec.rb
@@ -2,9 +2,40 @@ require 'spec_helper'
 
 RSpec.describe "Manage workflow roles", type: :feature do
   let(:user) { create(:user) }
+  let(:one_step_workflow) do
+    {
+      workflows: [
+        {
+          name: "one_step",
+          label: "One-step mediated deposit workflow",
+          description: "A single-step workflow for mediated deposit",
+          actions: [
+            {
+              name: "deposit",
+              from_states: [],
+              transition_to: "pending_review"
+            },
+            {
+              name: "approve",
+              from_states: [
+                {
+                  names: ["pending_review"],
+                  roles: ["approving"]
+                }
+              ],
+              transition_to: "complete",
+              methods: [
+                "CurationConcerns::Workflow::ActivateObject"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  end
   before do
     allow_any_instance_of(CurationConcerns::Admin::WorkflowRolesController).to receive(:authorize!).with(:read, :admin_dashboard).and_return(true)
-    CurationConcerns::Workflow::WorkflowImporter.generate_from_json_file(path: "#{EngineCart.destination}/config/workflows/default_workflow.json")
+    CurationConcerns::Workflow::WorkflowImporter.new(data: one_step_workflow.as_json).call
     CurationConcerns::Workflow::PermissionGenerator.call(roles: Sipity::Role.all,
                                                          workflow: Sipity::Workflow.last,
                                                          agents: user)
@@ -12,6 +43,6 @@ RSpec.describe "Manage workflow roles", type: :feature do
 
   it "shows the roles" do
     visit '/admin/workflow_roles'
-    expect(page).to have_content 'default - reviewing'
+    expect(page).to have_content 'one_step - approving'
   end
 end

--- a/spec/services/curation_concerns/workflow/workflow_importer_spec.rb
+++ b/spec/services/curation_concerns/workflow/workflow_importer_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe CurationConcerns::Workflow::WorkflowImporter do
         result = described_class.generate_from_json_file(path: path)
       end.to change { Sipity::Workflow.count }.by(1)
       expect(result).to match_array(kind_of(Sipity::Workflow))
-      expect(result.first.label).to eq "Digital collections workflow"
-      expect(result.first.description).to eq "A multi-step workflow for digital collections"
+      expect(result.first.label).to eq "Default workflow"
+      expect(result.first.description).to eq "A single submission step, default workflow"
     end
   end
 end


### PR DESCRIPTION
This PR creates a new 0-step workflow for CC that merely mimics the current workflow. That is, this does not change the behavior of the application for end-users.