### PR TITLE
Changing derivatives job to perform_now

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -12,6 +12,6 @@ class CharacterizeJob < ActiveJob::Base
     file_set.characterization_proxy.save!
     file_set.update_index
     file_set.parent.in_collections.each(&:update_index) if file_set.parent
-    CreateDerivativesJob.perform_later(file_set, file_id, filename)
+    CreateDerivativesJob.perform_now(file_set, file_id, filename)
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -25,7 +25,7 @@ describe CharacterizeJob do
       expect(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
       expect(file).to receive(:save!)
       expect(file_set).to receive(:update_index)
-      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      expect(CreateDerivativesJob).to receive(:perform_now).with(file_set, file.id, filename)
       described_class.perform_now(file_set, file.id)
     end
   end
@@ -46,7 +46,7 @@ describe CharacterizeJob do
       allow(Hydra::Works::CharacterizationService).to receive(:run).with(file, filename)
       allow(file).to receive(:save!)
       allow(file_set).to receive(:update_index)
-      allow(CreateDerivativesJob).to receive(:perform_later).with(file_set, file.id, filename)
+      allow(CreateDerivativesJob).to receive(:perform_now).with(file_set, file.id, filename)
     end
     it "reindexes the collection" do
       expect(collection).to receive(:update_index)


### PR DESCRIPTION
This allows for characterization and derivatives generation to be performed in the same context,
which is safer if a file is being passed in.

To give some context for why I am asking for this change I am calling a perform_now on characterization passing in a file name, and the deleting the file that I am passing to characterization.  The problem is the perform_later for derivatives then does not get access to the file.

@projecthydra/sufia-code-reviewers

