### PR TITLE
Removing length limit on identifier PairTree path

### DIFF
--- a/app/services/curation_concerns/working_directory.rb
+++ b/app/services/curation_concerns/working_directory.rb
@@ -48,7 +48,7 @@ module CurationConcerns
         end
 
         def full_filename(id, original_name)
-          pair = id.scan(/..?/).first(4)
+          pair = id.scan(/..?/)
           File.join(CurationConcerns.config.working_path, *pair, original_name)
         end
     end

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'active-fedora', '>= 10.3.0.rc1'
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'breadcrumbs_on_rails', '>= 3.0.1', '< 4'
-  spec.add_dependency 'jquery-ui-rails'
+  spec.add_dependency 'jquery-ui-rails', '~> 5.0.5'
   spec.add_dependency 'simple_form', '~> 3.1'
   spec.add_dependency 'hydra-editor', '>= 2', '< 4'
   spec.add_dependency 'rails_autolink'

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -4,7 +4,7 @@ describe CharacterizeJob do
   include CurationConcerns::FactoryHelpers
 
   let(:file_set)    { FileSet.new(id: file_set_id) }
-  let(:file_set_id) { 'abc12345678' }
+  let(:file_set_id) { 'abc12345' }
   let(:file_path)   { Rails.root + 'tmp' + 'uploads' + 'ab' + 'c1' + '23' + '45' + 'picture.png' }
   let(:filename)    { file_path.to_s }
   let(:file) do

--- a/spec/services/curation_concerns/working_directory_spec.rb
+++ b/spec/services/curation_concerns/working_directory_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe CurationConcerns::WorkingDirectory do
+  let(:path1) { described_class.send(:full_filename, 'abcdefghijklmnop1', 'foo.tif') }
+  let(:path2) { described_class.send(:full_filename, 'abcdefghijklmnop2', 'foo.tif') }
+
+  describe "#full_filename" do
+    it "generates unique filenames for different files" do
+      expect(path1).not_to eq(path2)
+    end
+  end
+end


### PR DESCRIPTION
Removes the current limit of 4 PairTree directory levels when storing uploaded files.  This prevents collisions when uploading files and using identifiers that are more than 8 characters long.

@projecthydra/sufia-code-reviewers