### PR TITLE
Short, guaranteed-unique path for uploaded files

### DIFF
--- a/app/services/curation_concerns/working_directory.rb
+++ b/app/services/curation_concerns/working_directory.rb
@@ -48,7 +48,7 @@ module CurationConcerns
         end
 
         def full_filename(id, original_name)
-          pair = id.scan(/..?/)
+          pair = id.scan(/..?/).first(4).push(id)
           File.join(CurationConcerns.config.working_path, *pair, original_name)
         end
     end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -5,7 +5,7 @@ describe CharacterizeJob do
 
   let(:file_set)    { FileSet.new(id: file_set_id) }
   let(:file_set_id) { 'abc12345' }
-  let(:file_path)   { Rails.root + 'tmp' + 'uploads' + 'ab' + 'c1' + '23' + '45' + 'picture.png' }
+  let(:file_path)   { Rails.root + 'tmp' + 'uploads' + 'ab' + 'c1' + '23' + '45' + 'abc12345' + 'picture.png' }
   let(:filename)    { file_path.to_s }
   let(:file) do
     Hydra::PCDM::File.new.tap do |f|


### PR DESCRIPTION
See #1112 

Reverting to shortened path, but adding full id as last directory to ensure uniqueness.

@projecthydra/sufia-code-reviewers