### PR TITLE
Signaure of a SearchBuilder supports one or two arguments

### DIFF
--- a/app/search_builders/curation_concerns/collection_search_builder.rb
+++ b/app/search_builders/curation_concerns/collection_search_builder.rb
@@ -9,9 +9,9 @@ module CurationConcerns
   class CollectionSearchBuilder < ::SearchBuilder
     include FilterByType
     # Defines which search_params_logic should be used when searching for Collections
-    def initialize(context)
+    def initialize(*)
       @rows = 100
-      super(context)
+      super
     end
 
     # @return [String] Solr field name indicating default sort order


### PR DESCRIPTION
Sufia uses it with two arguments, so the change in #1105 was
backwards incompatible.  This restores the compatibility

Once merged this should be backported to the 1.7-stable branch.