### PR TITLE
Change ActiveFedora dependency to disallow 10.3.0-rc*

### DIFF
--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'hydra-head', '>= 10.3.0', '< 11'
-  spec.add_dependency 'active-fedora', '>= 10.3.0.rc1'
+  spec.add_dependency 'active-fedora', '>= 10.3.0'
   spec.add_dependency 'blacklight', '~> 6.3'
   spec.add_dependency 'breadcrumbs_on_rails', '>= 3.0.1', '< 4'
   spec.add_dependency 'jquery-ui-rails', '~> 5.0.5'


### PR DESCRIPTION
The dependency should be on `>= 10.3.0` rather than `>= 10.3.0.rc1`.

Failing tests look like they are due to #1124.

@projecthydra/sufia-code-reviewers
