### PR TITLE
Adding check for presenter since it is required for the view

### DIFF
--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -218,6 +218,7 @@ module CurationConcerns
         message = I18n.t("curation_concerns.workflow.unauthorized")
         respond_to do |wants|
           wants.html do
+            unavailable_presenter
             flash[:notice] = message
             render 'unavailable', status: :unauthorized
           end
@@ -235,6 +236,10 @@ module CurationConcerns
             render plain: message, status: :unauthorized
           end
         end
+      end
+
+      def unavailable_presenter
+        @presenter ||= show_presenter.new(::SolrDocument.find(params[:id]), current_ability, request)
       end
   end
 end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -20,6 +20,7 @@ describe CurationConcerns::GenericWorksController do
       get :show, params: { id: work }
       expect(response.code).to eq '401'
       expect(response).to render_template(:unavailable)
+      expect(assigns[:presenter]).to be_instance_of CurationConcerns::WorkShowPresenter
       expect(flash[:notice]).to eq 'The work is not currently available because it has not yet completed the approval process'
     end
   end


### PR DESCRIPTION
refs projecthydra/sufia/issues/2990

If we are displaying the unavailable view and the workflow is in a suppressed state then the presenter does not get set in the usual way becuase document_not_found! raise an exception during the setting or the presenter.  At this point we need the presenter to be set for the view to render correctly, so set it without checking for suppression.

@projecthydra/sufia-code-reviewers
