### PR TITLE
Don't depend on User.groups returning a 'registered' pseudo-group

### DIFF
--- a/spec/services/curation_concerns/workflow/permission_query_spec.rb
+++ b/spec/services/curation_concerns/workflow/permission_query_spec.rb
@@ -165,12 +165,18 @@ module CurationConcerns
           subject { described_class.scope_processing_agents_for(user: nil) }
           it { is_expected.to eq([]) }
         end
+
         context 'when user is persisted' do
           let(:user) { create(:user) }
+          before do
+            allow(user).to receive(:groups).and_return(['librarians'])
+          end
+
           subject { described_class.scope_processing_agents_for(user: user) }
+
           it 'will equal [kind_of(Sipity::Agent)]' do
             is_expected.to contain_exactly(PowerConverter.convert_to_sipity_agent(user),
-                                           PowerConverter.convert_to_sipity_agent(Group.new('registered')))
+                                           PowerConverter.convert_to_sipity_agent(Group.new('librarians')))
           end
         end
       end


### PR DESCRIPTION
Back ported from
https://github.com/projecthydra-labs/hyrax/commit/cbd4bdcb2c79eb77ea7c2b74a53ea9dea6a4982b

Fixes #1142