### PR TITLE
Add optimistic locking on metadata editing

### DIFF
--- a/app/actors/curation_concerns/optimistic_lock_validator.rb
+++ b/app/actors/curation_concerns/optimistic_lock_validator.rb
@@ -1,0 +1,28 @@
+module CurationConcerns
+  # Validates that the submitted version is the most recent version in the datastore.
+  # Caveat: we are not detecting if the version is changed by a different process between
+  # the time this validator is run and when the object is saved
+  class OptimisticLockValidator < Actors::AbstractActor
+    class_attribute :version_field
+    self.version_field = 'version'
+
+    def update(attributes)
+      validate_lock(version_attribute(attributes)) && next_actor.update(attributes)
+    end
+
+    private
+
+      # @return [Boolean] returns true if the lock is missing or
+      #                   if it matches the current object version.
+      def validate_lock(version)
+        return true if version.blank? || version == curation_concern.etag
+        curation_concern.errors.add(:base, :conflict)
+        false
+      end
+
+      # Removes the version attribute
+      def version_attribute(attributes)
+        attributes.delete(version_field)
+      end
+  end
+end

--- a/app/assets/javascripts/curation_concerns/file_manager/sorting.es6
+++ b/app/assets/javascripts/curation_concerns/file_manager/sorting.es6
@@ -15,18 +15,14 @@ export default class SortManager {
   }
 
   persist() {
-    let params = {}
-    params[this.singular_class_name] = {
-      "ordered_member_ids": this.order
-    }
-    params["_method"] = "PATCH"
     this.element.addClass("pending")
     this.element.removeClass("success")
     this.element.removeClass("failure")
     let persisting = $.post(
       `/concern/${this.class_name}/${this.id}.json`,
-      params
-    ).done(() => {
+      this.params()
+    ).done((response) => {
+      this.element.data('version', response.version)
       this.element.data("current-order", this.order)
       this.element.addClass("success")
       this.element.removeClass("failure")
@@ -37,6 +33,16 @@ export default class SortManager {
       this.element.removeClass("pending")
     })
     return persisting
+  }
+
+  params() {
+    let params = {}
+    params[this.singular_class_name] = {
+      "version": this.version,
+      "ordered_member_ids": this.order
+    }
+    params["_method"] = "PATCH"
+    return params
   }
 
   get_sort_position(item) {
@@ -86,6 +92,10 @@ export default class SortManager {
         return $(this).data("reorder-id")
       }
     ).toArray()
+  }
+
+  get version() {
+    return this.element.data('version')
   }
 
   get alpha_sort_button() {

--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -22,6 +22,11 @@ module CurationConcerns
     module ClassMethods
       def curation_concern_type=(curation_concern_type)
         load_and_authorize_resource class: curation_concern_type, instance_name: :curation_concern, except: [:show, :file_manager, :inspect_work]
+
+        # Load the fedora resource to get the etag.
+        # No need to authorize for the file manager, because it does authorization via the presenter.
+        load_resource class: curation_concern_type, instance_name: :curation_concern, only: :file_manager
+
         self._curation_concern_type = curation_concern_type
       end
 
@@ -104,7 +109,7 @@ module CurationConcerns
     end
 
     def file_manager
-      presenter
+      @form = Forms::FileManagerForm.new(curation_concern, current_ability)
     end
 
     def inspect_work

--- a/app/forms/curation_concerns/forms/file_manager_form.rb
+++ b/app/forms/curation_concerns/forms/file_manager_form.rb
@@ -1,0 +1,27 @@
+module CurationConcerns
+  module Forms
+    class FileManagerForm
+      include HydraEditor::Form
+      self.terms = []
+      delegate :id, :thumbnail_id, :representative_id, :to_s, to: :model
+      attr_reader :current_ability, :request
+      def initialize(work, ability)
+        super(work)
+        @current_ability = ability
+        @request = nil
+      end
+
+      def version
+        model.etag
+      end
+
+      delegate :member_presenters, to: :member_presenter_factory
+
+      private
+
+        def member_presenter_factory
+          MemberPresenterFactory.new(work, ability)
+        end
+    end
+  end
+end

--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -27,6 +27,10 @@ module CurationConcerns
         super(model)
       end
 
+      def version
+        model.etag
+      end
+
       # The value for embargo_relase_date and lease_expiration_date should not
       # be initialized to empty string
       def initialize_field(key)
@@ -58,6 +62,10 @@ module CurationConcerns
           else
             super
           end
+        end
+
+        def build_permitted_params
+          super + [:version]
         end
       end
 

--- a/app/models/concerns/curation_concerns/ability.rb
+++ b/app/models/concerns/curation_concerns/ability.rb
@@ -14,6 +14,7 @@ module CurationConcerns
 
       # user can version if they can edit
       alias_action :versions, to: :update
+      alias_action :file_manager, to: :update
 
       if admin?
         admin_permissions

--- a/app/models/concerns/curation_concerns/work_behavior.rb
+++ b/app/models/concerns/curation_concerns/work_behavior.rb
@@ -24,6 +24,12 @@ module CurationConcerns::WorkBehavior
     self.indexer = CurationConcerns::WorkIndexer
   end
 
+  # TODO: Move this into ActiveFedora
+  def etag
+    raise "Unable to produce an etag for a unsaved object" unless persisted?
+    ldp_source.head.etag
+  end
+
   module ClassMethods
     # This governs which partial to draw when you render this type of object
     def _to_partial_path #:nodoc:

--- a/app/presenters/curation_concerns/member_presenter_factory.rb
+++ b/app/presenters/curation_concerns/member_presenter_factory.rb
@@ -1,0 +1,70 @@
+module CurationConcerns
+  # Creates the presenters of the members (member works and file sets) of a specific object
+  class MemberPresenterFactory
+    class_attribute :file_presenter_class, :work_presenter_class
+    # modify this attribute to use an alternate presenter class for the files
+    self.file_presenter_class = FileSetPresenter
+
+    # modify this attribute to use an alternate presenter class for the child works
+    self.work_presenter_class = WorkShowPresenter
+
+    def initialize(work, ability, request = nil)
+      @work = work
+      @current_ability = ability
+      @request = request
+    end
+
+    delegate :id, to: :@work
+    attr_reader :current_ability, :request
+
+    # @param [Array<String>] ids a list of ids to build presenters for
+    # @param [Class] presenter_class the type of presenter to build
+    # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
+    def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
+      PresenterFactory.build_presenters(ids, presenter_class, *presenter_factory_arguments)
+    end
+
+    # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
+    def file_set_presenters
+      @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
+    end
+
+    # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
+    def work_presenters
+      @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
+    end
+
+    private
+
+      # TODO: Extract this to ActiveFedora::Aggregations::ListSource
+      def ordered_ids
+        @ordered_ids ||= begin
+                           ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
+                                                           rows: 10_000,
+                                                           fl: "ordered_targets_ssim")
+                                                    .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
+                         end
+      end
+
+      # These are the file sets that belong to this work, but not necessarily
+      # in order.
+      # Arbitrarily maxed at 10 thousand; had to specify rows due to solr's default of 10
+      def file_set_ids
+        @file_set_ids ||= begin
+                            ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
+                                                            rows: 10_000,
+                                                            fl: ActiveFedora.id_field,
+                                                            fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
+                                                     .flat_map { |x| x.fetch(ActiveFedora.id_field, []) }
+                          end
+      end
+
+      def presenter_factory_arguments
+        [current_ability, request]
+      end
+
+      def composite_presenter_class
+        CompositePresenterFactory.new(file_presenter_class, work_presenter_class, ordered_ids & file_set_ids)
+      end
+  end
+end

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -4,16 +4,10 @@ module CurationConcerns
     include PresentsAttributes
     attr_accessor :solr_document, :current_ability, :request
 
-    class_attribute :collection_presenter_class, :file_presenter_class, :work_presenter_class
+    class_attribute :collection_presenter_class
 
     # modify this attribute to use an alternate presenter class for the collections
     self.collection_presenter_class = CollectionPresenter
-
-    # modify this attribute to use an alternate presenter class for the files
-    self.file_presenter_class = FileSetPresenter
-
-    # modify this attribute to use an alternate presenter class for the child works
-    self.work_presenter_class = self
 
     # Methods used by blacklight helpers
     delegate :has?, :first, :fetch, :export_formats, :export_as, to: :solr_document
@@ -41,11 +35,6 @@ module CurationConcerns
              :lease_expiration_date, :rights, :source, :thumbnail_id, :representative_id,
              :member_of_collection_ids, to: :solr_document
 
-    # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
-    def file_set_presenters
-      @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
-    end
-
     def workflow
       @workflow ||= WorkflowPresenter.new(solr_document, current_ability)
     end
@@ -66,22 +55,6 @@ module CurationConcerns
             result
           end
         end
-    end
-
-    # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
-    def work_presenters
-      @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
-    end
-
-    # @param [Array<String>] ids a list of ids to build presenters for
-    # @param [Class] presenter_class the type of presenter to build
-    # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
-    def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
-      PresenterFactory.build_presenters(ids, presenter_class, *presenter_factory_arguments)
-    end
-
-    def composite_presenter_class
-      CompositePresenterFactory.new(file_presenter_class, work_presenter_class, ordered_ids & file_set_ids)
     end
 
     # Get presenters for the collections this work is a member of via the member_of_collections association.
@@ -107,37 +80,20 @@ module CurationConcerns
       graph.dump(:ttl)
     end
 
-    private
+    delegate :member_presenters, :file_set_presenters, :work_presenters, to: :member_presenter_factory
 
-      def graph
-        GraphExporter.new(solr_document, request).fetch
-      end
+    private
 
       def presenter_factory_arguments
         [current_ability, request]
       end
 
-      # TODO: Extract this to ActiveFedora::Aggregations::ListSource
-      def ordered_ids
-        @ordered_ids ||= begin
-                           ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
-                                                           rows: 10_000,
-                                                           fl: "ordered_targets_ssim")
-                                                    .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
-                         end
+      def member_presenter_factory
+        MemberPresenterFactory.new(solr_document, current_ability, request)
       end
 
-      # These are the file sets that belong to this work, but not necessarily
-      # in order.
-      # Arbitrarily maxed at 10 thousand; had to specify rows due to solr's default of 10
-      def file_set_ids
-        @file_set_ids ||= begin
-                            ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
-                                                            rows: 10_000,
-                                                            fl: ActiveFedora.id_field,
-                                                            fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
-                                                     .flat_map { |x| x.fetch(ActiveFedora.id_field, []) }
-                          end
+      def graph
+        GraphExporter.new(solr_document, request).fetch
       end
   end
 end

--- a/app/services/curation_concerns/actors/actor_factory.rb
+++ b/app/services/curation_concerns/actors/actor_factory.rb
@@ -8,7 +8,8 @@ module CurationConcerns
       end
 
       def self.stack_actors(curation_concern)
-        [AddAsMemberOfCollectionsActor,
+        [OptimisticLockValidator,
+         AddAsMemberOfCollectionsActor,
          AddToWorkActor,
          AssignRepresentativeActor,
          AttachFilesActor,

--- a/app/views/curation_concerns/base/_file_manager_member_resource_options.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_member_resource_options.html.erb
@@ -1,10 +1,10 @@
       <div class="form-group radio_buttons member_resource_options">
         <span class="radio">
-          <%= radio_button_tag "thumbnail_id", node.id, @presenter.thumbnail_id == node.id, id: "thumbnail_id_#{node.id}", class: "radio_buttons" %>
+          <%= radio_button_tag "thumbnail_id", node.id, @form.thumbnail_id == node.id, id: "thumbnail_id_#{node.id}", class: "radio_buttons" %>
           <%= label_tag "thumbnail_id_#{node.id}", "Thumbnail" %>
         </span>
         <span class="radio">
-          <%= radio_button_tag "representative_id", node.id, @presenter.representative_id == node.id, id: "representative_id_#{node.id}", class: "radio_buttons" %>
+          <%= radio_button_tag "representative_id", node.id, @form.representative_id == node.id, id: "representative_id_#{node.id}", class: "radio_buttons" %>
           <%= label_tag "representative_id_#{node.id}", "Representative Media" %>
         </span>
       </div>

--- a/app/views/curation_concerns/base/_file_manager_members.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_members.html.erb
@@ -1,5 +1,13 @@
-<ul id="sortable" data-id="<%= @presenter.id %>" data-class-name="<%= @presenter.model_name.plural %>" data-singular-class-name="<%= @presenter.model_name.singular %>" class="list-unstyled grid clearfix">
- <% @presenter.member_presenters.each do |member| %>
-   <%= render "file_manager_member", node: member %>
- <% end %>
-</ul>
+<%= content_tag :ul,
+                id: "sortable",
+                class: "list-unstyled grid clearfix",
+                data: {
+                  id: @form.id,
+                  "class-name" => @form.model_name.plural,
+                  "singular-class-name" => @form.model_name.singular,
+                  version: @form.version
+                } do %>
+  <% @form.member_presenters.each do |member| %>
+    <%= render "file_manager_member", node: member %>
+  <% end %>
+<% end %>

--- a/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
+++ b/app/views/curation_concerns/base/_file_manager_resource_form.html.erb
@@ -1,5 +1,5 @@
 <div class="resource-form-container">
-  <%= simple_form_for [main_app, @presenter], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
+  <%= simple_form_for [main_app, @form], remote: true, html: { id: 'resource-form', 'data-type': 'json' } do |f| %>
     <%= f.input :thumbnail_id, as: :hidden, input_html: { data: {member_link: 'thumbnail_id'}} %>
     <%= f.input :representative_id, as: :hidden, input_html: { data: {member_link: 'representative_id'}} %>
   <% end %>

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -12,6 +12,9 @@
 
   <div class="row">
     <div class="col-md-12 form-actions">
+      <%# TODO: If we start using ActionCable, we could listen for object updates and
+                alert the user that the object has changed by someone else %>
+      <%= f.input CurationConcerns::OptimisticLockValidator.version_field, as: :hidden unless f.object.new_record? %>
       <%= f.submit class: 'btn btn-primary require-contributor-agreement' %>
       <% if curation_concern.new_record? %>
         <%= link_to 'Cancel', main_app.root_path, class: 'btn btn-link' %>

--- a/app/views/curation_concerns/base/file_manager.html.erb
+++ b/app/views/curation_concerns/base/file_manager.html.erb
@@ -1,11 +1,11 @@
 <h1><%= t("file_manager.link_text") %></h1>
 <ul class="breadcrumb">
   <li>
-    Back to <%= link_to @presenter.to_s, [main_app, @presenter] %>
+    Back to <%= link_to @form.to_s, [main_app, @form] %>
   </li>
 </ul>
 
-<% if !@presenter.member_presenters.empty? %>
+<% if !@form.member_presenters.empty? %>
   <div data-action="file-manager">
     <div class="col-md-3" id="file-manager-tools">
       <h2>Toolbar</h2>

--- a/app/views/curation_concerns/base/show.json.jbuilder
+++ b/app/views/curation_concerns/base/show.json.jbuilder
@@ -1,1 +1,2 @@
 json.extract! @curation_concern, *[:id] + @curation_concern.class.fields.select {|f| ![:has_model].include? f}
+json.version @curation_concern.etag

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -1,4 +1,8 @@
 en:
+  activemodel:
+    errors:
+      messages:
+        conflict: "Another user has made a change to that %{model} since you accessed the edit form."
   curation_concerns:
     admin:
       workflow_roles:

--- a/spec/actors/curation_concerns/optimistic_lock_validator_spec.rb
+++ b/spec/actors/curation_concerns/optimistic_lock_validator_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe CurationConcerns::OptimisticLockValidator do
+  let(:update_actor) do
+    double('update actor', update: true,
+                           curation_concern: work,
+                           user: depositor)
+  end
+
+  let(:actor) do
+    CurationConcerns::Actors::ActorStack.new(work, depositor, [described_class])
+  end
+
+  let(:depositor) { create(:user) }
+  let(:work) { create(:generic_work) }
+
+  describe "update" do
+    before do
+      allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(update_actor)
+      allow(update_actor).to receive(:update).and_return(true)
+    end
+
+    subject { actor.update(attributes) }
+
+    context "when version is blank" do
+      let(:attributes) { { version: '' } }
+      it { is_expected.to be true }
+    end
+
+    context "when version is provided" do
+      context "and the version is current" do
+        let(:attributes) { { version: work.etag } }
+
+        it "returns true and calls the next actor without the version attribute" do
+          expect(update_actor).to receive(:update).with({}).and_return(true)
+          expect(subject).to be true
+        end
+      end
+
+      context "and the version is not current" do
+        let(:attributes) { { version: "W/\"ab2e8552cb5f7f00f91d2b223eca45849c722301\"" } }
+
+        it "returns false and sets an error" do
+          expect(subject).to be false
+          expect(work.errors[:base]).to include "Another user has made a change to that Generic work since you accessed the edit form."
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -341,7 +341,7 @@ describe CurationConcerns::GenericWorksController do
     it "is successful" do
       get :file_manager, params: { id: work.id }
       expect(response).to be_success
-      expect(assigns(:presenter)).not_to be_blank
+      expect(assigns(:form)).not_to be_blank
     end
   end
 

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -22,6 +22,14 @@ describe CurationConcerns::Forms::WorkForm do
   let(:ability) { nil }
   let(:form) { PirateShipForm.new(curation_concern, ability) }
 
+  describe "#version" do
+    before do
+      allow(curation_concern).to receive(:etag).and_return('123456')
+    end
+    subject { form.version }
+    it { is_expected.to eq '123456' }
+  end
+
   describe "#select_files" do
     let(:curation_concern) { create(:work_with_one_file) }
     let(:title) { curation_concern.file_sets.first.title.first }

--- a/spec/presenters/curation_concerns/member_presenter_factory_spec.rb
+++ b/spec/presenters/curation_concerns/member_presenter_factory_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe CurationConcerns::MemberPresenterFactory do
+  describe "#file_set_presenters" do
+    describe "getting presenters from factory" do
+      let(:solr_document) { SolrDocument.new(attributes) }
+      let(:attributes) { {} }
+      let(:ability) { double }
+      let(:request) { double }
+      let(:factory) { described_class.new(solr_document, ability, request) }
+      let(:presenter_class) { double }
+      before do
+        allow(factory).to receive(:composite_presenter_class).and_return(presenter_class)
+        allow(factory).to receive(:ordered_ids).and_return(['12', '33'])
+        allow(factory).to receive(:file_set_ids).and_return(['33', '12'])
+      end
+
+      it "uses the set class" do
+        expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
+          .with(['12', '33'], presenter_class, ability, request)
+        factory.file_set_presenters
+      end
+    end
+  end
+end

--- a/spec/presenters/curation_concerns/work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/work_show_presenter_spec.rb
@@ -102,34 +102,14 @@ describe CurationConcerns::WorkShowPresenter do
         expect(presenter.file_set_presenters.map(&:id)).not_to include another_work.id
       end
     end
-
-    describe "getting presenters from factory" do
-      let(:attributes) { {} }
-      let(:presenter_class) { double }
-      before do
-        allow(presenter).to receive(:composite_presenter_class).and_return(presenter_class)
-        allow(presenter).to receive(:ordered_ids).and_return(['12', '33'])
-        allow(presenter).to receive(:file_set_ids).and_return(['33', '12'])
-      end
-
-      it "uses the set class" do
-        expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
-          .with(['12', '33'], presenter_class, ability, request)
-        presenter.file_set_presenters
-      end
-    end
   end
 
   describe "#representative_presenter" do
     let(:obj) { create(:work_with_representative_file) }
     let(:attributes) { obj.to_solr }
-    let(:presenter_class) { double }
-    before do
-      allow(presenter).to receive(:composite_presenter_class).and_return(presenter_class)
-    end
     it "has a representative" do
       expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
-        .with([obj.members[0].id], presenter_class, ability, request).and_return ["abc"]
+        .with([obj.members[0].id], CurationConcerns::CompositePresenterFactory, ability, request).and_return ["abc"]
       expect(presenter.representative_presenter).to eq("abc")
     end
   end

--- a/spec/views/curation_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'curation_concerns/base/_form.html.erb', type: :view do
+  let(:ability) { double }
+  let(:user) { stub_model(User) }
+  let(:form) do
+    CurationConcerns::GenericWorkForm.new(work, ability)
+  end
+
+  before do
+    # view.lookup_context.view_paths.push 'app/views/curation_concerns'
+    # allow(controller).to receive(:current_user).and_return(user)
+    allow(view).to receive(:curation_concern).and_return(work)
+  end
+
+  let(:page) do
+    view.simple_form_for form do |f|
+      render 'curation_concerns/base/form', f: f
+    end
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  context "when the work has been saved before" do
+    before do
+      allow(work).to receive(:new_record?).and_return(false)
+      assign(:form, form)
+    end
+
+    let(:work) { stub_model(GenericWork, id: '456', etag: '123456') }
+
+    it "renders the form with the version" do
+      expect(page).to have_selector("input#generic_work_version[value=\"123456\"]", visible: false)
+    end
+  end
+end

--- a/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/file_manager.html.erb_spec.rb
@@ -26,19 +26,21 @@ RSpec.describe "curation_concerns/base/file_manager.html.erb" do
   end
   let(:resource) { FactoryGirl.build(:file_set) }
 
-  let(:parent) { FactoryGirl.build(:generic_work) }
-  let(:parent_solr_doc) do
-    SolrDocument.new(parent.to_solr.merge(id: "resource"), nil)
-  end
-  let(:parent_presenter) do
-    CurationConcerns::WorkShowPresenter.new(parent_solr_doc, nil, view)
+  let(:parent) { build(:generic_work) }
+
+  let(:form) do
+    CurationConcerns::Forms::FileManagerForm.new(parent, nil)
   end
 
   let(:blacklight_config) { CatalogController.new.blacklight_config }
 
   before do
-    allow(parent_presenter).to receive(:member_presenters).and_return([file_set, member])
-    assign(:presenter, parent_presenter)
+    allow(parent).to receive(:etag).and_return("123456")
+    allow(parent).to receive(:persisted?).and_return(true)
+    allow(parent).to receive(:id).and_return('resource')
+
+    allow(form).to receive(:member_presenters).and_return([file_set, member])
+    assign(:form, form)
     # Blacklight nonsense
     allow(view).to receive(:dom_class) { '' }
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)

--- a/spec/views/curation_concerns/base/show.json.jbuilder_spec.rb
+++ b/spec/views/curation_concerns/base/show.json.jbuilder_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe 'curation_concerns/base/show.json.jbuilder' do
-  let(:curation_concern) { FactoryGirl.create(:generic_work) }
+  let(:curation_concern) { create(:generic_work) }
 
   before do
+    allow(curation_concern).to receive(:etag).and_return('W/"87f79d2244ded4239ad1f0e822c8429b1e72b66c"')
     assign(:curation_concern, curation_concern)
     render
   end
@@ -17,5 +18,6 @@ describe 'curation_concerns/base/show.json.jbuilder' do
     expected_fields.each do |field_symbol|
       expect(json).to have_key(field_symbol.to_s)
     end
+    expect(json['version']).to eq 'W/"87f79d2244ded4239ad1f0e822c8429b1e72b66c"'
   end
 end


### PR DESCRIPTION
This prevents an edit form loaded a long time ago from overwriting more
recent edits.

Ref https://github.com/projecthydra/sufia/issues/3055

