### PR TITLE
Use the correct variables for initializing the FileManagerForm

### DIFF
--- a/app/forms/curation_concerns/forms/file_manager_form.rb
+++ b/app/forms/curation_concerns/forms/file_manager_form.rb
@@ -20,7 +20,7 @@ module CurationConcerns
       private
 
         def member_presenter_factory
-          MemberPresenterFactory.new(work, ability)
+          MemberPresenterFactory.new(model, current_ability)
         end
     end
   end

--- a/spec/forms/curation_concerns/forms/file_manager_form_spec.rb
+++ b/spec/forms/curation_concerns/forms/file_manager_form_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe CurationConcerns::Forms::FileManagerForm do
+  let(:work) { create(:work) }
+  let(:ability) { instance_double Ability }
+  let(:form) { described_class.new(work, ability) }
+
+  describe "#member_presenters" do
+    subject { form.member_presenters }
+    let(:factory) { instance_double(CurationConcerns::MemberPresenterFactory, member_presenters: result) }
+    let(:result) { double }
+    before do
+      allow(CurationConcerns::MemberPresenterFactory).to receive(:new).with(work, ability).and_return(factory)
+    end
+    it "is delegated to the MemberPresenterFactory" do
+      expect(subject).to eq result
+    end
+  end
+end


### PR DESCRIPTION
Previously this method was untested and was using uninitialized variables. 