### PR TITLE
prevents child relationship when parent is owned by a different depositor

### DIFF
--- a/app/actors/curation_concerns/actors/add_to_work_actor.rb
+++ b/app/actors/curation_concerns/actors/add_to_work_actor.rb
@@ -22,13 +22,17 @@ module CurationConcerns
             work.save
           end
 
-          # add to new
+          # add to new so long as the depositor for the parent and child matches, otherwise inject an error
           (new_work_ids - curation_concern.in_works_ids).each do |work_id|
             work = ::ActiveFedora::Base.find(work_id)
-            work.ordered_members << curation_concern
-            work.save
+            if work.depositor != curation_concern.depositor
+              curation_concern.errors[:in_works_ids] << "Works can only be related to each other if they were deposited by the same user."
+            else
+              work.ordered_members << curation_concern
+              work.save
+            end
           end
-          true
+          curation_concern.errors[:in_works_ids].empty?
         end
     end
   end

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -4,6 +4,7 @@
     <div class="alert alert-danger fade in">
       <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
       <a class="close" data-dismiss="alert" href="#">&times;</a>
+      <%= render 'form_in_works_error', f: f %>
     </div>
   <% end %>
 

--- a/app/views/curation_concerns/base/_form_in_works_error.html.erb
+++ b/app/views/curation_concerns/base/_form_in_works_error.html.erb
@@ -1,0 +1,3 @@
+<% unless f.object.model.errors[:in_works_ids].empty? %>
+  <%= f.full_error(:in_works_ids) %>
+<% end %>

--- a/spec/actors/curation_concerns/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/work_actor_spec.rb
@@ -88,8 +88,14 @@ describe CurationConcerns::Actors::GenericWorkActor do
           )
         end
         it "attaches the parent" do
+          allow(curation_concern).to receive(:depositor).and_return(parent.depositor)
           expect(subject.create(attributes)).to be true
           expect(curation_concern.in_works).to eq [parent]
+        end
+        it "does not attach the parent" do
+          allow(curation_concern).to receive(:depositor).and_return("blahblahblah")
+          expect(subject.create(attributes)).to be false
+          expect(curation_concern.in_works).to eq []
         end
       end
 
@@ -204,6 +210,7 @@ describe CurationConcerns::Actors::GenericWorkActor do
         old_parent.save!
       end
       it "attaches the parent" do
+        allow(curation_concern).to receive(:depositor).and_return(parent.depositor)
         expect(subject.update(attributes)).to be true
         expect(curation_concern.in_works).to eq [parent]
 
@@ -224,6 +231,7 @@ describe CurationConcerns::Actors::GenericWorkActor do
         old_parent.save!
       end
       it "removes the old parent" do
+        allow(curation_concern).to receive(:depositor).and_return(old_parent.depositor)
         expect(subject.update(attributes)).to be true
         expect(curation_concern.in_works).to eq []
         expect(old_parent.reload.members).to eq []

--- a/spec/features/create_child_work_spec.rb
+++ b/spec/features/create_child_work_spec.rb
@@ -64,5 +64,19 @@ feature 'Creating a new child Work', :workflow do
 
       expect(curation_concern.reload.in_works_ids.length).to eq 2
     end
+
+    context "with a parent that doesn't belong to this user" do
+      let(:new_user) { create(:user) }
+      let(:new_parent) { create(:generic_work, user: new_user) }
+      it "fails to update" do
+        visit "/concern/parent/#{parent.id}/generic_works/#{curation_concern.id}/edit"
+        first("input#generic_work_in_works_ids", visible: false).set new_parent.id
+        first("input#parent_id", visible: false).set new_parent.id
+        click_on "Update Generic work"
+
+        expect(new_parent.reload.ordered_members.to_a.length).to eq 0
+        expect(page).to have_content "Works can only be related to each other if they were deposited by the same user."
+      end
+    end
   end
 end


### PR DESCRIPTION
First step in surfacing a fix for Sufia Issue 3042: projecthydra/sufia#3042