### PR TITLE
prevents user from adding ordered_member_ids which they do not own

### DIFF
--- a/app/actors/curation_concerns/actors/apply_order_actor.rb
+++ b/app/actors/curation_concerns/actors/apply_order_actor.rb
@@ -3,8 +3,7 @@ module CurationConcerns
     class ApplyOrderActor < AbstractActor
       def update(attributes)
         ordered_member_ids = attributes.delete(:ordered_member_ids)
-        sync_members(ordered_member_ids)
-        apply_order(ordered_member_ids) && next_actor.update(attributes)
+        sync_members(ordered_member_ids) && apply_order(ordered_member_ids) && next_actor.update(attributes)
       end
 
       private
@@ -20,10 +19,14 @@ module CurationConcerns
 
           (ordered_member_ids - existing_members_ids).each do |work_id|
             work = ::ActiveFedora::Base.find(work_id)
-            curation_concern.ordered_members << work
+            if work.depositor != curation_concern.depositor
+              curation_concern.errors[:ordered_member_ids] << "Works can only be related to each other if they were deposited by the same user."
+            else
+              curation_concern.ordered_members << work
+              curation_concern.save
+            end
           end
-          curation_concern.save
-          true
+          curation_concern.errors[:ordered_member_ids].empty?
         end
 
         def apply_order(new_order)

--- a/spec/actors/curation_concerns/apply_order_actor_spec.rb
+++ b/spec/actors/curation_concerns/apply_order_actor_spec.rb
@@ -59,6 +59,26 @@ describe CurationConcerns::Actors::ApplyOrderActor do
       end
     end
 
+    context 'with ordered_member_ids that include a work owned by another user' do
+      let(:other_user) { create(:user) }
+      let(:attributes) { { ordered_member_ids: [child.id] } }
+      let(:root_actor) { double }
+      before do
+        allow(CurationConcerns::Actors::RootActor).to receive(:new).and_return(root_actor)
+        allow(root_actor).to receive(:update).with({}).and_return(true)
+        # TODO: This can be moved into the Factory
+        child.title = ["Generic Title"]
+        child.apply_depositor_metadata(other_user.user_key)
+        child.save!
+        curation_concern.apply_depositor_metadata(user.user_key)
+        curation_concern.save!
+      end
+
+      it "fails to attach the parent" do
+        expect(subject.update(attributes)).to be false
+      end
+    end
+
     context 'without an ordered_member_id that was associated with the curation concern' do
       let(:curation_concern) { create(:work_with_two_children, user: user) }
       let(:attributes) { { ordered_member_ids: ["BlahBlah2"] } }


### PR DESCRIPTION
Adding a child work which is not owned by the current user fix for Sufia Issue 3042: projecthydra/sufia#3042