### PR TITLE
[Backport] Do not display agent presenter if agent has zero workflow responsibilities

### DIFF
--- a/app/presenters/curation_concerns/admin/workflow_role_presenter.rb
+++ b/app/presenters/curation_concerns/admin/workflow_role_presenter.rb
@@ -16,6 +16,10 @@ module CurationConcerns
           @agent = agent
         end
 
+        def responsibilities_present?
+          @agent.workflow_responsibilities.any?
+        end
+
         def responsibilities
           @agent.workflow_responsibilities.each do |responsibility|
             yield ResponsibilityPresenter.new(responsibility)

--- a/app/views/curation_concerns/admin/workflow_roles/index.html.erb
+++ b/app/views/curation_concerns/admin/workflow_roles/index.html.erb
@@ -11,7 +11,7 @@
           <tr>
             <td><%= user.user_key %></td>
             <% agent_presenter = @presenter.presenter_for(user) %>
-            <% if agent_presenter %>
+            <% if agent_presenter && agent_presenter.responsibilities_present? %>
               <td>
                 <ul>
                   <% agent_presenter.responsibilities do |responsibility_presenter| %>
@@ -42,4 +42,3 @@
     </div>
   </div>
 </div>
-

--- a/spec/views/curation_concerns/admin/workflow_roles/index.html.erb_spec.rb
+++ b/spec/views/curation_concerns/admin/workflow_roles/index.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'curation_concerns/admin/workflow_roles/index.html.erb', type: :view do
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+  let(:presenter) do
+    CurationConcerns::Admin::WorkflowRolePresenter.new
+  end
+
+  before do
+    assign(:presenter, presenter)
+    allow(view).to receive(:admin_workflow_roles_path).and_return('/admin/workflow_roles')
+  end
+
+  context 'with no users having workflow roles' do
+    it 'displays "No Roles" for each user' do
+      render
+      expect(rendered).to have_content('No roles', count: 2)
+    end
+  end
+
+  context 'with some users having workflow roles' do
+    before do
+      # Force user instances to have corresponding sipity agents
+      user1.to_sipity_agent
+      user2.to_sipity_agent
+    end
+    it 'displays roles for each user' do
+      render
+      expect(rendered.match(/<ul>\s+<\/ul>/m)).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Pulls over a workaround from Sufia: https://github.com/projecthydra/sufia/pull/3080

Backported from master

@projecthydra/sufia-code-reviewers
