### PR TITLE
Add field to store whether a workflow allows setting access grants

### DIFF
--- a/app/services/curation_concerns/workflow/workflow_importer.rb
+++ b/app/services/curation_concerns/workflow/workflow_importer.rb
@@ -72,6 +72,7 @@ module CurationConcerns
           workflow = Sipity::Workflow.find_or_initialize_by(name: configuration.fetch(:name)) do |wf|
             wf.label = configuration.fetch(:label, nil)
             wf.description = configuration.fetch(:description, nil)
+            wf.allows_access_grant = configuration.fetch(:allows_access_grant, nil)
             wf.save!
           end
 

--- a/app/services/curation_concerns/workflow/workflow_schema.rb
+++ b/app/services/curation_concerns/workflow/workflow_schema.rb
@@ -34,6 +34,7 @@ module CurationConcerns
         required(:name).filled(:str?) # Sipity::Workflow#name
         optional(:label).filled(:str?) # Sipity::Workflow#label
         optional(:description).filled(:str?) # Sipity::Workflow#description
+        optional(:allows_access_grant).filled(:bool?) # Sipity::Workflow#allows_access_grant?
         required(:actions).each do
           required(:name).filled(:str?) # Sipity::WorkflowAction#name
           required(:from_states).each do

--- a/db/migrate/20170308175556_add_allows_access_grant_to_workflow.rb
+++ b/db/migrate/20170308175556_add_allows_access_grant_to_workflow.rb
@@ -1,0 +1,5 @@
+class AddAllowsAccessGrantToWorkflow < ActiveRecord::Migration
+  def change
+    add_column :sipity_workflows, :allows_access_grant, :boolean
+  end
+end

--- a/spec/services/curation_concerns/workflow/workflow_importer_spec.rb
+++ b/spec/services/curation_concerns/workflow/workflow_importer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CurationConcerns::Workflow::WorkflowImporter do
           "name": "ulra_submission",
           "label": "This is the label",
           "description": "This description could get really long",
+          "allows_access_grant": true,
           "actions": [{
             "name": "approve",
             "transition_to": "reviewed",
@@ -42,8 +43,10 @@ RSpec.describe CurationConcerns::Workflow::WorkflowImporter do
         result = described_class.generate_from_json_file(path: path)
       end.to change { Sipity::Workflow.count }.by(1)
       expect(result).to match_array(kind_of(Sipity::Workflow))
-      expect(result.first.label).to eq "This is the label"
-      expect(result.first.description).to eq "This description could get really long"
+      first_workflow = result.first
+      expect(first_workflow.label).to eq "This is the label"
+      expect(first_workflow.description).to eq "This description could get really long"
+      expect(first_workflow.allows_access_grant?).to be true
     end
   end
 end

--- a/spec/services/curation_concerns/workflow/workflow_schema_spec.rb
+++ b/spec/services/curation_concerns/workflow/workflow_schema_spec.rb
@@ -8,6 +8,7 @@ module CurationConcerns
           workflows: [
             {
               name: "valid",
+              allows_access_grant: true,
               actions: [
                 {
                   name: "finalize_digitization",


### PR DESCRIPTION
Backport of #1164

Sufia allows depositors to set other users who can edit a work.  This is
perfect for a zero step workflow, but for a mediated deposit workflow,
we don't want anyone to be able to edit the work once it is accepted.

We need a place to store whether we should be showing the UI widget that
allows the creator to share access.

Ref https://github.com/projecthydra/sufia/issues/3134
