### PR TITLE
Removing an exclusion for a non-existent file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,6 @@ Metrics/ClassLength:
   Exclude:
     - lib/curation_concerns/configuration.rb
     - 'lib/generators/curation_concerns/templates/catalog_controller.rb'
-    - 'app/actors/curation_concerns/file_set_actor.rb'
 
 Metrics/ModuleLength:
   Exclude:
@@ -119,12 +118,6 @@ Style/GlobalVars:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/ClassVars:
-  Exclude:
-    - 'lib/curation_concerns/models.rb'
-    - 'lib/curation_concerns/models/engine.rb'
-    - 'app/models/concerns/curation_concerns/file_set/versions.rb'
-
 Style/SignalException:
   Enabled: false
 
@@ -163,13 +156,8 @@ RSpec/NotToNot:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/javascripts/jasmine_spec.rb'
-    - 'spec/tasks/rake_spec.rb'
     - 'spec/abilities/**/*'
     - 'spec/views/**/*'
     - 'spec/routing/**/*'
     - 'spec/inputs/**/*'
     - 'spec/conversions/**/*'
-
-RSpec/DescribedClass:
-  Exclude:
-    - 'spec/actors/curation_concerns/manages_embargoes_actor_spec.rb'


### PR DESCRIPTION
Using the following script, found several files that were not
referenced.

```ruby
require 'psych'
yaml = Psych.load_file('./.rubocop.yml')

def read(node)
  if node.is_a?(Hash)
    node.each_pair do |key, value|
      read(value)
    end
  elsif node.is_a?(Array)
    node.each do |value|
      read(value)
    end
  elsif node.is_a?(String)
    return unless node =~ /.rb\Z/
    return if node =~ /\*/
    return if File.exist?(node)
    puts node
  end
end
read(yaml)
```

Fixes #issuenumber ; refs #issuenumber

Present tense short summary (50 characters or less)

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
* 
* 
* 

@projecthydra/sufia-code-reviewers
