### PR TITLE
jobs: lock FileSets while attaching Files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: ruby
 cache: bundler
 sudo: false
+
 rvm:
   - 2.3.1
+
+services: redis
+
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
@@ -11,5 +15,6 @@ env:
       RDF_VERSION=1.99.1
     - RAILS_VERSION=5.0.0.1
       RDF_VERSION=2.1.1
+
 before_script:
   - jdk_switcher use oraclejdk8

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,4 +1,6 @@
 class CharacterizeJob < ActiveJob::Base
+  include CurationConcerns::Lockable
+
   queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
@@ -7,11 +9,16 @@ class CharacterizeJob < ActiveJob::Base
   def perform(file_set, file_id, filepath = nil)
     filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
     raise LoadError, "#{file_set.class.characterization_proxy} was not found" unless file_set.characterization_proxy?
-    Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
-    Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
-    file_set.characterization_proxy.save!
-    file_set.update_index
-    file_set.parent.in_collections.each(&:update_index) if file_set.parent
+
+    # Prevent other jobs from trying to modify the FileSet at the same time
+    acquire_lock_for(file_set.id) do
+      Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
+      Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
+      file_set.characterization_proxy.save!
+      file_set.update_index
+      file_set.parent.in_collections.each(&:update_index) if file_set.parent
+    end
+
     CreateDerivativesJob.perform_later(file_set, file_id, filename)
   end
 end


### PR DESCRIPTION
Currently
```ruby
actor = CurationConcerns::Actors::FileSetActor.new(file_set, user)
actor.create_content('file1')
actor.create_content('file2', 'restored')
```

Can fail due to background jobs trying to create and/or modify the FileSet at the same time. See e.g. https://gist.github.com/anonymous/1f8160b427359cf913dd0f25730cf155

@projecthydra/sufia-code-reviewers
