### PR TITLE
Allow full redis urls

### DIFF
--- a/app/services/curation_concerns/lock_manager.rb
+++ b/app/services/curation_concerns/lock_manager.rb
@@ -27,8 +27,7 @@ module CurationConcerns
 
       def uri
         @uri ||= begin
-          opts = options
-          opts[:url].blank? ? URI("#{opts[:scheme]}://#{opts[:host]}:#{opts[:port]}").to_s : URI(opts[:url]).to_s
+          options[:url].blank? ? URI("#{options[:scheme]}://#{options[:host]}:#{options[:port]}").to_s : URI(options[:url]).to_s
         end
       end
 

--- a/app/services/curation_concerns/lock_manager.rb
+++ b/app/services/curation_concerns/lock_manager.rb
@@ -28,7 +28,7 @@ module CurationConcerns
       def uri
         @uri ||= begin
           opts = options
-          URI("#{opts[:scheme]}://#{opts[:host]}:#{opts[:port]}").to_s
+          opts[:url].blank? ? URI("#{opts[:scheme]}://#{opts[:host]}:#{opts[:port]}").to_s : URI(opts[:url]).to_s
         end
       end
 


### PR DESCRIPTION
Fixes #1172 

Allow a full url for redis connections.

This adds support for a new `url` option in `config/redis.yml` and won't break existing configurations.
The current parser doesn't allow for password and db number.

@projecthydra/sufia-code-reviewers
