### PR TITLE
Data Migration task for upgrade to v2

### DIFF
--- a/lib/curation_concerns/data_migration/collections_migration.rb
+++ b/lib/curation_concerns/data_migration/collections_migration.rb
@@ -1,0 +1,16 @@
+module CurationConcerns
+  module DataMigration
+    class CollectionsMigration
+      def self.run
+        ::Collection.all.each do |collection|
+          collection.members.each do |member|
+            member.member_of_collections << collection
+            member.save
+          end
+          collection.members = []
+          collection.save
+        end
+      end
+    end
+  end
+end

--- a/lib/curation_concerns/version.rb
+++ b/lib/curation_concerns/version.rb
@@ -1,3 +1,3 @@
 module CurationConcerns
-  VERSION = '2.0.0.rc1'.freeze
+  VERSION = '2.0.0.rc2'.freeze
 end

--- a/lib/tasks/curation_concerns.rake
+++ b/lib/tasks/curation_concerns.rake
@@ -9,7 +9,7 @@ namespace :curation_concerns do
   end
   namespace :migrate do
     desc "Migrate collections"
-    task collections: :index do
+    task collections: :environment do
       CurationConcerns::DataMigration::CollectionsMigration.run
     end
   end

--- a/lib/tasks/curation_concerns.rake
+++ b/lib/tasks/curation_concerns.rake
@@ -10,18 +10,9 @@ namespace :curation_concerns do
   namespace :migrate do
     desc "Migrate collections"
     task collections: :index do
-      Collection.all.each do |collection|
-        collection.members.each do |member|
-          member.member_of_collections << collection
-          member.save
-        end
-        collection.members = []
-        collection.save
-      end
+      CurationConcerns::DataMigration::CollectionsMigration.run
     end
   end
-end
-namespace :curation_concerns do
   namespace :solr do
     desc "Enqueue a job to resolrize the repository objects"
     task reindex: :environment do

--- a/lib/tasks/curation_concerns.rake
+++ b/lib/tasks/curation_concerns.rake
@@ -7,4 +7,25 @@ namespace :curation_concerns do
       puts "  #{model}: #{model.count}"
     end
   end
+  namespace :migrate do
+    desc "Migrate collections"
+    task collections: :index do
+      Collection.all.each do |collection|
+        collection.members.each do |member|
+          member.member_of_collections << collection
+          member.save
+        end
+        collection.members = []
+        collection.save
+      end
+    end
+  end
+end
+namespace :curation_concerns do
+  namespace :solr do
+    desc "Enqueue a job to resolrize the repository objects"
+    task reindex: :environment do
+      ResolrizeJob.perform_later
+    end
+  end
 end

--- a/spec/lib/curation_concerns/data_migration/collections_migration_spec.rb
+++ b/spec/lib/curation_concerns/data_migration/collections_migration_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe CurationConcerns::DataMigration::CollectionsMigration do
+  let(:collection1) { create(:collection, id: 'alien', title: ['alien movies']) }
+  let(:collection2) { create(:collection, id: 'predator', title: ['predator movies']) }
+  let(:work1) { create(:work, title: ['alien resurrection']) }
+  let(:work2) { create(:work, title: ['the predator']) }
+  let(:work3) { create(:work, title: ['alien vs. predator']) }
+
+  before do
+    collection1.members = [work1, work3]
+    collection2.members = [work2, work3]
+  end
+
+  describe '.run' do
+    it 'moves relationship from collection#members to curation_concern#member_of_collections' do
+      expect(collection1.members.to_a.size).to eq 2
+      expect(collection2.members.to_a.size).to eq 2
+      expect(work1.member_of_collections.to_a.size).to eq 0
+      expect(work2.member_of_collections.to_a.size).to eq 0
+      expect(work3.member_of_collections.to_a.size).to eq 0
+      described_class.run
+      expect(collection1.reload.members.to_a.size).to eq 0
+      expect(collection2.reload.members.to_a.size).to eq 0
+      expect(work1.reload.member_of_collections.to_a.size).to eq 1
+      expect(work1.member_of_collection_ids.first).to eq 'alien'
+      expect(work2.reload.member_of_collections.to_a.size).to eq 1
+      expect(work2.member_of_collection_ids.first).to eq 'predator'
+      expect(work3.reload.member_of_collections.to_a.size).to eq 2
+      expect(work3.member_of_collection_ids).to include 'predator'
+      expect(work3.member_of_collection_ids).to include 'alien'
+    end
+  end
+end


### PR DESCRIPTION
Add a data migration task to support the upgrade from cc 1.x to cc 2. Updates all collections and members thereof to reverse the membership relationship.

@projecthydra/sufia-code-reviewers
